### PR TITLE
Benchmarker: Ability to configure a matrix of benchmarks easily

### DIFF
--- a/drools-planner-benchmark/src/main/java/org/drools/planner/benchmark/config/XmlPlannerBenchmarkFactory.java
+++ b/drools-planner-benchmark/src/main/java/org/drools/planner/benchmark/config/XmlPlannerBenchmarkFactory.java
@@ -98,6 +98,7 @@ public class XmlPlannerBenchmarkFactory {
     public XmlPlannerBenchmarkFactory configureFromTemplate(Reader reader, Object model) {
         Configuration cfg = new Configuration();
         cfg.setObjectWrapper(new DefaultObjectWrapper());
+        cfg.setNumberFormat("computer"); // don't do any Freemarker magic to numbers
         try {
             return this.configureFromTemplate(new Template("benchmarkTemplate.ftl", reader, cfg, "UTF-8"), model);
         } catch (IOException e) {


### PR DESCRIPTION
This commit introduces new methods to the XmlPlannerBenchmarkFactory, allowing the user to configure their benchmarks from a Freemarker template.

There are two ways of loading templates:
- With implicit Freemarker configuration. User simply provides a Reader/InputStream for their template and Planner handles the rest.
- With explicit Freemarker configuration. User provides Freemarker's Template object, which will require them to create their own Configuration.

This way, users can either choose the defaults or opt in for full Freemarker power at the expense of writing more code. Also, users have the option to provide a data model for their templates - so that they can separate the template logic from the data.

This pull request doesn't change anything in the pre-existing code. Merely adds a few light-weight methods.
