### PR TITLE
PLANNER-56 Standard deviation is shown in the best score table

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SolverBenchmark.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SolverBenchmark.java
@@ -26,6 +26,8 @@ import org.optaplanner.core.config.solver.XmlSolverFactory;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.impl.score.ScoreUtils;
+import org.optaplanner.core.impl.score.definition.ScoreDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +48,10 @@ public class SolverBenchmark {
     private List<SingleBenchmark> singleBenchmarkList = null;
 
     private int failureCount = -1;
-    private Score totalScore = null;
+    private Score totalScore = null;    
+       
+    private double totalAverageSquaredDifference[];    
+    
     private Score totalWinningScoreDifference = null;
     private ScoreDifferencePercentage averageWorstScoreDifferencePercentage = null;
     // The average of the average is not just the overall average if the SingleBenchmark's timeMillisSpend differ
@@ -56,7 +61,8 @@ public class SolverBenchmark {
     private Integer ranking = null;
 
     public SolverBenchmark(DefaultPlannerBenchmark plannerBenchmark) {
-        this.plannerBenchmark = plannerBenchmark;
+        this.plannerBenchmark = plannerBenchmark;        
+        
     }
 
     public String getName() {
@@ -137,6 +143,7 @@ public class SolverBenchmark {
 
     public void benchmarkingEnded() {
         determineTotalsAndAverages();
+        determineDifferencesFromAverage();
     }
 
     protected void determineTotalsAndAverages() {
@@ -172,6 +179,32 @@ public class SolverBenchmark {
             averageAverageCalculateCountPerSecond = totalAverageCalculateCountPerSecond / (long) successCount;
         }
     }
+        
+    protected void determineDifferencesFromAverage(){        
+        
+        Score average = getAverageScore();
+        if (average==null) return;
+        
+        boolean firstNonFailure = true;
+        for (SingleBenchmark singleBenchmark : singleBenchmarkList) {
+            if (!singleBenchmark.isFailure()) {                
+                if (firstNonFailure) {                                                           
+                    //we do power operation on "double" to avoid common overflow when operating with scores > 500 000
+                    totalAverageSquaredDifference = ScoreUtils.extractLevelDoubles(singleBenchmark.getScore().subtract(average));                                          
+                    for (int i = 0; i< totalAverageSquaredDifference.length; i++) {                                                
+                        totalAverageSquaredDifference[i] = Math.pow(totalAverageSquaredDifference[i], 2.0);                                                
+                    }                                                       
+                    firstNonFailure = false;
+                } else {
+                    double temp[] = ScoreUtils.extractLevelDoubles(singleBenchmark.getScore().subtract(average));                                                        
+                    
+                    for (int i = 0; i< totalAverageSquaredDifference.length; i++) {                                                
+                        totalAverageSquaredDifference[i] += Math.pow(temp[i], 2.0);                                                
+                    }                                                      
+                }
+            }
+        }
+    }
 
     public int getSuccessCount() {
         return singleBenchmarkList.size() - failureCount;
@@ -194,6 +227,28 @@ public class SolverBenchmark {
             return null;
         }
         return totalScore.divide(getSuccessCount());
+    }
+    
+     public String getScoreStandardDeviation(){
+        if (totalAverageSquaredDifference == null || totalScore == null) {
+            return null;
+        }        
+        
+        int successCount = getSuccessCount();        
+        
+        StringBuilder builder = new StringBuilder();
+        
+        // do sqrt(totalAverageSquaredDifference/count) and build a String
+        int i=0;
+        for (Number number :  totalAverageSquaredDifference){             
+            if (i>0){
+                builder.append("/");
+            }
+            builder.append((int) Math.floor(Math.pow(number.doubleValue() / successCount, 0.5)));            
+            i++;
+        }
+        
+        return builder.toString();        
     }
 
     public Score getAverageWinningScoreDifference() {

--- a/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
+++ b/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
@@ -138,6 +138,7 @@
                                         <th>${problemBenchmark.name}</th>
                                     </#list>
                                         <th>Average</th>
+                                        <th>Standard Deviation</th>
                                         <th>Ranking</th>
                                     </tr>
                                 <#list benchmarkReport.plannerBenchmark.solverBenchmarkList as solverBenchmark>
@@ -156,6 +157,7 @@
                                             </#if>
                                         </#list>
                                         <td>${solverBenchmark.averageScore!""}</td>
+                                        <td>${solverBenchmark.scoreStandardDeviation!""}</td>
                                         <td><@addSolverRankingBadge solverBenchmark=solverBenchmark/></td>
                                     </tr>
                                 </#list>


### PR DESCRIPTION
First, I have tested the approach B) (as stated https://issues.jboss.org/browse/PLANNER-56) but as you said,there was an overflow. So I did it the inferior way. Unfortunately, I cannot put an array of doubles back to Score since there is no useful method for that in the Score interface. 

For returning Score, I tried to ScoreDefinition.parseScore() as well. But it couldn't be used because it subsequently calls particular Score.parseScore() function and it requires the String in a format a  "999hard/999soft" (with labels). 

Now, the result is returned as String in getScoreStandardDeviation() method and displayed in the report (as levels separated by "/"). Are you OK with that?
