### PR TITLE
Implement bendable score of BigDecimal type

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScore.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.api.score.buildin.bendablebigdecimal;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.optaplanner.core.api.score.AbstractScore;
+import org.optaplanner.core.api.score.FeasibilityScore;
+import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.impl.score.buildin.bendable.BendableScoreDefinition;
+
+/**
+ * This {@link Score} is based on n levels of {@link BigDecimal} constraints.
+ * The number of levels is bendable at configuration time.
+ * <p/>
+ * This class is immutable.
+ * <p/>
+ * The {@link #getHardLevelsSize()} and {@link #getSoftLevelsSize()} must be the same as in the
+ * {@link BendableScoreDefinition} used.
+ * @see Score
+ */
+public final class BendableBigDecimalScore extends AbstractScore<BendableBigDecimalScore>
+        implements FeasibilityScore<BendableBigDecimalScore> {
+
+    public static BendableBigDecimalScore parseScore(int hardLevelsSize, int softLevelsSize, String scoreString) {
+        int levelsSize = hardLevelsSize + softLevelsSize;
+        String[] levelStrings = parseLevelStrings(BendableBigDecimalScore.class, scoreString, levelsSize);
+        BigDecimal[] hardScores = new BigDecimal[hardLevelsSize];
+        BigDecimal[] softScores = new BigDecimal[softLevelsSize];
+        for (int i = 0; i < hardScores.length; i++) {
+            hardScores[i] = parseLevelAsBigDecimal(BendableBigDecimalScore.class, scoreString, levelStrings[i]);
+        }
+        for (int i = 0; i < softScores.length; i++) {
+            softScores[i] = parseLevelAsBigDecimal(BendableBigDecimalScore.class, scoreString, levelStrings[hardScores.length + i]);
+        }
+        return valueOf(hardScores, softScores);
+    }
+
+    /**
+     * Creates a new {@link BendableBigDecimalScore}.
+     * @param hardScores never null, never change that array afterwards: it must be immutable
+     * @param softScores never null, never change that array afterwards: it must be immutable
+     * @return never null
+     */
+    public static BendableBigDecimalScore valueOf(BigDecimal[] hardScores, BigDecimal[] softScores) {
+        return new BendableBigDecimalScore(hardScores, softScores);
+    }
+
+    // ************************************************************************
+    // Fields
+    // ************************************************************************
+
+    private final BigDecimal[] hardScores;
+    private final BigDecimal[] softScores;
+
+    protected BendableBigDecimalScore(BigDecimal[] hardScores, BigDecimal[] softScores) {
+        this.hardScores = hardScores;
+        this.softScores = softScores;
+    }
+
+    // Intentionally no getters for the hardScores or softScores int arrays to guarantee that this class is immutable
+
+    public int getHardLevelsSize() {
+        return hardScores.length;
+    }
+
+    /**
+     * @param index 0 <= index < {@link #getHardLevelsSize()}
+     * @return higher is better
+     */
+    public BigDecimal getHardScore(int index) {
+        return hardScores[index];
+    }
+
+    public int getSoftLevelsSize() {
+        return softScores.length;
+    }
+
+    /**
+     * @param index 0 <= index < {@link #getSoftLevelsSize()}
+     * @return higher is better
+     */
+    public BigDecimal getSoftScore(int index) {
+        return softScores[index];
+    }
+
+    // ************************************************************************
+    // Worker methods
+    // ************************************************************************
+
+    public boolean isFeasible() {
+        for (BigDecimal hardScore : hardScores) {
+            int comparison = hardScore.compareTo(BigDecimal.ZERO);
+            if (comparison > 0) {
+                return true;
+            } else if (comparison < 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public BendableBigDecimalScore add(BendableBigDecimalScore augment) {
+        validateCompatible(augment);
+        BigDecimal[] newHardScores = new BigDecimal[hardScores.length];
+        BigDecimal[] newSoftScores = new BigDecimal[softScores.length];
+        for (int i = 0; i < newHardScores.length; i++) {
+            newHardScores[i] = hardScores[i].add(augment.getHardScore(i));
+        }
+        for (int i = 0; i < newSoftScores.length; i++) {
+            newSoftScores[i] = softScores[i].add(augment.getSoftScore(i));
+        }
+        return new BendableBigDecimalScore(newHardScores, newSoftScores);
+    }
+
+    public BendableBigDecimalScore subtract(BendableBigDecimalScore subtrahend) {
+        validateCompatible(subtrahend);
+        BigDecimal[] newHardScores = new BigDecimal[hardScores.length];
+        BigDecimal[] newSoftScores = new BigDecimal[softScores.length];
+        for (int i = 0; i < newHardScores.length; i++) {
+            newHardScores[i] = hardScores[i].subtract(subtrahend.getHardScore(i));
+        }
+        for (int i = 0; i < newSoftScores.length; i++) {
+            newSoftScores[i] = softScores[i].subtract(subtrahend.getSoftScore(i));
+        }
+        return new BendableBigDecimalScore(newHardScores, newSoftScores);
+    }
+
+    public BendableBigDecimalScore multiply(double multiplicand) {
+        BigDecimal[] newHardScores = new BigDecimal[hardScores.length];
+        BigDecimal[] newSoftScores = new BigDecimal[softScores.length];
+        BigDecimal bigDecimalMultiplicand = BigDecimal.valueOf(multiplicand);
+        for (int i = 0; i < newHardScores.length; i++) {
+            newHardScores[i] = hardScores[i].multiply(bigDecimalMultiplicand);
+        }
+        for (int i = 0; i < newSoftScores.length; i++) {
+            newSoftScores[i] = softScores[i].multiply(bigDecimalMultiplicand);
+        }
+        return new BendableBigDecimalScore(newHardScores, newSoftScores);
+    }
+
+    public BendableBigDecimalScore divide(double divisor) {
+        BigDecimal[] newHardScores = new BigDecimal[hardScores.length];
+        BigDecimal[] newSoftScores = new BigDecimal[softScores.length];
+        BigDecimal bigDecimalDivisor = BigDecimal.valueOf(divisor);
+        for (int i = 0; i < newHardScores.length; i++) {
+            BigDecimal hardScore = hardScores[i];
+            newHardScores[i] = hardScore.divide(bigDecimalDivisor, hardScore.scale(), RoundingMode.FLOOR);
+        }
+        for (int i = 0; i < newSoftScores.length; i++) {
+            BigDecimal softScore = softScores[i];
+            newSoftScores[i] = softScore.divide(bigDecimalDivisor, softScore.scale(), RoundingMode.FLOOR);
+        }
+        return new BendableBigDecimalScore(newHardScores, newSoftScores);
+    }
+
+    public BendableBigDecimalScore power(double exponent) {
+        BigDecimal[] newHardScores = new BigDecimal[hardScores.length];
+        BigDecimal[] newSoftScores = new BigDecimal[softScores.length];
+        BigDecimal actualExponent = BigDecimal.valueOf(exponent);
+        // The (unspecified) scale/precision of the exponent should have no impact on the returned scale/precision
+        // TODO FIXME remove .intValue() so non-integer exponents produce correct results
+        // None of the normal Java libraries support BigDecimal.pow(BigDecimal)
+        for (int i = 0; i < newHardScores.length; i++) {
+            BigDecimal hardScore = hardScores[i]; 
+            newHardScores[i] = hardScore.pow(actualExponent.intValue()).setScale(hardScore.scale());
+        }
+        for (int i = 0; i < newSoftScores.length; i++) {
+            BigDecimal softScore = softScores[i]; 
+            newSoftScores[i] = softScore.pow(actualExponent.intValue()).setScale(softScore.scale());
+        }
+        return new BendableBigDecimalScore(newHardScores, newSoftScores);
+    }
+
+    public BendableBigDecimalScore negate() {
+        BigDecimal[] newHardScores = new BigDecimal[hardScores.length];
+        BigDecimal[] newSoftScores = new BigDecimal[softScores.length];
+        for (int i = 0; i < newHardScores.length; i++) {
+            newHardScores[i] = hardScores[i].negate();
+        }
+        for (int i = 0; i < newSoftScores.length; i++) {
+            newSoftScores[i] = softScores[i].negate();
+        }
+        return new BendableBigDecimalScore(newHardScores, newSoftScores);
+    }
+
+    public Number[] toLevelNumbers() {
+        Number[] levelNumbers = new Number[hardScores.length + softScores.length];
+        for (int i = 0; i < hardScores.length; i++) {
+            levelNumbers[i] = hardScores[i];
+        }
+        for (int i = 0; i < softScores.length; i++) {
+            levelNumbers[hardScores.length + i] = softScores[i];
+        }
+        return levelNumbers;
+    }
+
+    public boolean equals(Object o) {
+        // A direct implementation (instead of EqualsBuilder) to avoid dependencies
+        if (this == o) {
+            return true;
+        } else if (o instanceof BendableBigDecimalScore) {
+            BendableBigDecimalScore other = (BendableBigDecimalScore) o;
+            if (getHardLevelsSize() != other.getHardLevelsSize()
+                    || getSoftLevelsSize() != other.getSoftLevelsSize()) {
+                return false;
+            }
+            for (int i = 0; i < hardScores.length; i++) {
+                if (!hardScores[i].equals(other.getHardScore(i))) {
+                    return false;
+                }
+            }
+            for (int i = 0; i < softScores.length; i++) {
+                if (!softScores[i].equals(other.getSoftScore(i))) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public int hashCode() {
+        // A direct implementation (instead of HashCodeBuilder) to avoid dependencies
+        int hashCode = 17;
+        for (BigDecimal hardScore : hardScores) {
+            hashCode = hashCode * 37 + hardScore.hashCode();
+        }
+        for (BigDecimal softScore : softScores) {
+            hashCode = hashCode * 37 + softScore.hashCode();
+        }
+        return hashCode;
+    }
+
+    public int compareTo(BendableBigDecimalScore other) {
+        // A direct implementation (instead of CompareToBuilder) to avoid dependencies
+        validateCompatible(other);
+        for (int i = 0; i < hardScores.length; i++) {
+            if (!hardScores[i].equals(other.getHardScore(i))) {
+                if (hardScores[i].compareTo(other.getHardScore(i)) < 0) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            }
+        }
+        for (int i = 0; i < softScores.length; i++) {
+            if (!softScores[i].equals(other.getSoftScore(i))) {
+                if (softScores[i].compareTo(other.getSoftScore(i)) < 0) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            }
+        }
+        return 0;
+    }
+
+    public String toString() {
+        StringBuilder s = new StringBuilder(((hardScores.length + softScores.length) * 4) + 1);
+        boolean first = true;
+        for (BigDecimal hardScore : hardScores) {
+            if (first) {
+                first = false;
+            } else {
+                s.append("/");
+            }
+            s.append(hardScore);
+        }
+        for (BigDecimal softScore : softScores) {
+            if (first) {
+                first = false;
+            } else {
+                s.append("/");
+            }
+            s.append(softScore);
+        }
+        return s.toString();
+    }
+
+    public void validateCompatible(BendableBigDecimalScore other) {
+        if (getHardLevelsSize() != other.getHardLevelsSize()) {
+            throw new IllegalArgumentException("The score (" + this
+                    + ") with hardScoreSize (" + getHardLevelsSize()
+                    + ") is not compatible with the other score (" + other
+                    + ") with hardScoreSize (" + other.getHardLevelsSize() + ").");
+        }
+        if (getSoftLevelsSize() != other.getSoftLevelsSize()) {
+            throw new IllegalArgumentException("The score (" + this
+                    + ") with softScoreSize (" + getSoftLevelsSize()
+                    + ") is not compatible with the other score (" + other
+                    + ") with softScoreSize (" + other.getSoftLevelsSize() + ").");
+        }
+    }
+
+    @Override
+    public boolean isCompatibleArithmeticArgument(Score otherScore) {
+        if (!(otherScore instanceof BendableBigDecimalScore)) {
+            return false;
+        }
+        BendableBigDecimalScore otherBendableScore = (BendableBigDecimalScore) otherScore;
+        return hardScores.length == otherBendableScore.hardScores.length
+                && softScores.length == otherBendableScore.softScores.length;
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHolder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHolder.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.api.score.buildin.bendablebigdecimal;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+import org.kie.api.runtime.rule.RuleContext;
+import org.optaplanner.core.api.score.Score;
+import org.optaplanner.core.api.score.holder.AbstractScoreHolder;
+
+/**
+ * @see BendableBigDecimalScore
+ */
+public class BendableBigDecimalScoreHolder extends AbstractScoreHolder {
+
+    private BigDecimal[] hardScores;
+    private BigDecimal[] softScores;
+
+    public BendableBigDecimalScoreHolder(boolean constraintMatchEnabled, int hardLevelsSize, int softLevelsSize) {
+        super(constraintMatchEnabled);
+        hardScores = new BigDecimal[hardLevelsSize];
+        Arrays.fill(hardScores, BigDecimal.ZERO);
+        softScores = new BigDecimal[softLevelsSize];
+        Arrays.fill(softScores, BigDecimal.ZERO);
+    }
+
+    public int getHardLevelsSize() {
+        return hardScores.length;
+    }
+
+    public BigDecimal getHardScore(int hardLevel) {
+        return hardScores[hardLevel];
+    }
+
+    @Deprecated
+    public void setHardScore(int hardLevel, BigDecimal hardScore) {
+        hardScores[hardLevel] = hardScore;
+    }
+
+    public int getSoftLevelsSize() {
+        return softScores.length;
+    }
+
+    public BigDecimal getSoftScore(int softLevel) {
+        return softScores[softLevel];
+    }
+
+    @Deprecated
+    public void setSoftScore(int softLevel, BigDecimal softScore) {
+        softScores[softLevel] = softScore;
+    }
+
+    // ************************************************************************
+    // Worker methods
+    // ************************************************************************
+
+    public void addHardConstraintMatch(RuleContext kcontext, final int hardLevel, final BigDecimal weight) {
+        hardScores[hardLevel] = hardScores[hardLevel].add(weight);
+        registerBigDecimalConstraintMatch(kcontext, hardLevel, weight, new Runnable() {
+            public void run() {
+                hardScores[hardLevel] = hardScores[hardLevel].subtract(weight);
+            }
+        });
+    }
+
+    public void addSoftConstraintMatch(RuleContext kcontext, final int softLevel, final BigDecimal weight) {
+        softScores[softLevel] = softScores[softLevel].add(weight);
+        registerBigDecimalConstraintMatch(kcontext, softLevel, weight, new Runnable() {
+            public void run() {
+                softScores[softLevel] = softScores[softLevel].subtract(weight);
+            }
+        });
+    }
+
+    public Score extractScore() {
+        return new BendableBigDecimalScore(Arrays.copyOf(hardScores, hardScores.length),
+                Arrays.copyOf(softScores, softScores.length));
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreDefinition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreDefinition.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.buildin.bendablebigdecimal;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScoreHolder;
+import org.optaplanner.core.impl.score.definition.AbstractFeasibilityScoreDefinition;
+import org.optaplanner.core.impl.score.trend.InitializingScoreTrend;
+
+public class BendableBigDecimalScoreDefinition extends AbstractFeasibilityScoreDefinition<BendableBigDecimalScore> {
+
+    private final int hardLevelsSize;
+    private final int softLevelsSize;
+
+    private double recursiveTimeGradientWeight = 0.50; // TODO this is a guess
+
+    public BendableBigDecimalScoreDefinition(int hardLevelsSize, int softLevelsSize) {
+        this.hardLevelsSize = hardLevelsSize;
+        this.softLevelsSize = softLevelsSize;
+    }
+
+    public int getHardLevelsSize() {
+        return hardLevelsSize;
+    }
+
+    public int getSoftLevelsSize() {
+        return softLevelsSize;
+    }
+
+    public double getRecursiveTimeGradientWeight() {
+        return recursiveTimeGradientWeight;
+    }
+
+    /**
+     * It's recommended to use a number which can be exactly represented as a double,
+     * such as 0.5, 0.25, 0.75, 0.125, ... but not 0.1, 0.2, ...
+     * @param recursiveTimeGradientWeight 0.0 <= recursiveTimeGradientWeight <= 1.0
+     */
+    public void setRecursiveTimeGradientWeight(double recursiveTimeGradientWeight) {
+        this.recursiveTimeGradientWeight = recursiveTimeGradientWeight;
+        if (recursiveTimeGradientWeight < 0.0 || recursiveTimeGradientWeight > 1.0) {
+            throw new IllegalArgumentException("Property recursiveTimeGradientWeight (" + recursiveTimeGradientWeight
+                    + ") must be greater or equal to 0.0 and smaller or equal to 1.0.");
+        }
+    }
+
+    // ************************************************************************
+    // Worker methods
+    // ************************************************************************
+
+    @Override
+    public int getLevelsSize() {
+        return hardLevelsSize + softLevelsSize;
+    }
+
+    @Override
+    public int getFeasibleLevelsSize() {
+        return hardLevelsSize;
+    }
+
+    public Class<BendableBigDecimalScore> getScoreClass() {
+        return BendableBigDecimalScore.class;
+    }
+
+    public BendableBigDecimalScore parseScore(String scoreString) {
+        return BendableBigDecimalScore.parseScore(hardLevelsSize, softLevelsSize, scoreString);
+    }
+
+    public BendableBigDecimalScore createScore(BigDecimal... scores) {
+        int levelsSize = hardLevelsSize + softLevelsSize;
+        if (scores.length != levelsSize) {
+            throw new IllegalArgumentException("The scores (" + Arrays.toString(scores)
+                    + ")'s length (" + scores.length
+                    + ") is not levelsSize (" + levelsSize + ").");
+        }
+        return BendableBigDecimalScore.valueOf(Arrays.copyOfRange(scores, 0, hardLevelsSize),
+                Arrays.copyOfRange(scores, hardLevelsSize, levelsSize));
+    }
+
+    public BendableBigDecimalScoreHolder buildScoreHolder(boolean constraintMatchEnabled) {
+        return new BendableBigDecimalScoreHolder(constraintMatchEnabled, hardLevelsSize, softLevelsSize);
+    }
+
+    public BendableBigDecimalScore buildOptimisticBound(InitializingScoreTrend initializingScoreTrend, BendableBigDecimalScore score) {
+        // TODO https://issues.jboss.org/browse/PLANNER-232
+        throw new UnsupportedOperationException("PLANNER-232: BigDecimalScore does not support bounds" +
+                " because a BigDecimal cannot represent infinity.");
+    }
+
+    public BendableBigDecimalScore buildPessimisticBound(InitializingScoreTrend initializingScoreTrend, BendableBigDecimalScore score) {
+        // TODO https://issues.jboss.org/browse/PLANNER-232
+        throw new UnsupportedOperationException("PLANNER-232: BigDecimalScore does not support bounds" +
+                " because a BigDecimal cannot represent infinity.");
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHolderTest.java
@@ -1,0 +1,46 @@
+package org.optaplanner.core.api.score.buildin.bendablebigdecimal;
+
+import java.math.BigDecimal;
+
+import org.junit.Test;
+import org.kie.api.runtime.rule.RuleContext;
+import org.optaplanner.core.api.score.holder.AbstractScoreHolderTest;
+
+import static org.junit.Assert.*;
+
+public class BendableBigDecimalScoreHolderTest extends AbstractScoreHolderTest {
+
+    @Test
+    public void addConstraintMatchWithConstraintMatch() {
+        addConstraintMatch(true);
+    }
+
+    @Test
+    public void addConstraintMatchWithoutConstraintMatch() {
+        addConstraintMatch(false);
+    }
+
+    public void addConstraintMatch(boolean constraintMatchEnabled) {
+        BendableBigDecimalScoreHolder scoreHolder = new BendableBigDecimalScoreHolder(constraintMatchEnabled, 1, 2);
+
+        // Rule match added
+        scoreHolder.addHardConstraintMatch(createRuleContext("scoreRule1"), 0, BigDecimal.valueOf(-1000));
+
+        RuleContext ruleContext2 = createRuleContext("scoreRule2");
+        scoreHolder.addHardConstraintMatch(ruleContext2, 0, BigDecimal.valueOf(-200)); // Rule match added
+        callUnMatch(ruleContext2); // Rule match removed
+
+        RuleContext ruleContext3 = createRuleContext("scoreRule3");
+        scoreHolder.addSoftConstraintMatch(ruleContext3, 0, BigDecimal.valueOf(-30)); // Rule match added
+        scoreHolder.addSoftConstraintMatch(ruleContext3, 0, BigDecimal.valueOf(-3)); // Rule match modified
+
+        scoreHolder.addSoftConstraintMatch(createRuleContext("scoreRule4"), 1, BigDecimal.valueOf(-4)); // Rule match added
+
+        assertEquals(BendableBigDecimalScore.valueOf(new BigDecimal[]{BigDecimal.valueOf(-1000)}, 
+                new BigDecimal[]{BigDecimal.valueOf(-3), BigDecimal.valueOf(-4)}), scoreHolder.extractScore());
+        if (constraintMatchEnabled) {
+            assertEquals(4, scoreHolder.getConstraintMatchTotals().size());
+        }
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.api.score.buildin.bendablebigdecimal;
+
+import java.math.BigDecimal;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.optaplanner.core.api.score.buildin.AbstractScoreTest;
+import org.optaplanner.core.impl.score.buildin.bendablebigdecimal.BendableBigDecimalScoreDefinition;
+import org.optaplanner.core.impl.testdata.util.SerializationTestUtils;
+
+import static org.junit.Assert.*;
+
+public class BendableBigDecimalScoreTest extends AbstractScoreTest {
+
+    private static final BigDecimal PLUS_4000 = BigDecimal.valueOf(4000);
+    private static final BigDecimal PLUS_300 = BigDecimal.valueOf(300);
+    private static final BigDecimal PLUS_280 = BigDecimal.valueOf(280);
+    private static final BigDecimal PLUS_25 = BigDecimal.valueOf(25);
+    private static final BigDecimal PLUS_24 = BigDecimal.valueOf(24);
+    private static final BigDecimal PLUS_21 = BigDecimal.valueOf(21);
+    private static final BigDecimal PLUS_20 = BigDecimal.valueOf(20);
+    private static final BigDecimal PLUS_19 = BigDecimal.valueOf(19);
+    private static final BigDecimal PLUS_16 = BigDecimal.valueOf(16);
+    private static final BigDecimal NINE = BigDecimal.valueOf(9);
+    private static final BigDecimal FIVE = BigDecimal.valueOf(5);
+    private static final BigDecimal FOUR = BigDecimal.valueOf(4);
+    private static final BigDecimal THREE = BigDecimal.valueOf(3);
+    private static final BigDecimal TWO = BigDecimal.valueOf(2);
+    private static final BigDecimal ONE = BigDecimal.ONE;
+    private static final BigDecimal ZERO = BigDecimal.ZERO;
+    private static final BigDecimal MINUS_ONE = ONE.negate();
+    private static final BigDecimal MINUS_THREE = THREE.negate();
+    private static final BigDecimal MINUS_FOUR = FOUR.negate();
+    private static final BigDecimal MINUS_FIVE = FIVE.negate();
+    private static final BigDecimal MINUS_TEN = BigDecimal.TEN.negate();
+    private static final BigDecimal MINUS_20 = PLUS_20.negate();
+    private static final BigDecimal MINUS_21 = PLUS_21.negate();
+    private static final BigDecimal MINUS_24 = PLUS_24.negate();
+    private static final BigDecimal MINUS_25 = PLUS_25.negate();
+    private static final BigDecimal MINUS_30 = BigDecimal.valueOf(-30);
+    private static final BigDecimal MINUS_300 = PLUS_300.negate();
+    private static final BigDecimal MINUS_320 = BigDecimal.valueOf(-320);
+    private static final BigDecimal MINUS_4000 = PLUS_4000.negate();
+    private static final BigDecimal MINUS_5000 = BigDecimal.valueOf(-5000);
+    private static final BigDecimal MINUS_8000 = BigDecimal.valueOf(-8000);
+    private static final BigDecimal MIN_INTEGER = BigDecimal.valueOf(Integer.MIN_VALUE);
+    
+    private BendableBigDecimalScoreDefinition scoreDefinitionHSS = new BendableBigDecimalScoreDefinition(1, 2);
+
+    @Test
+    public void parseScore() {
+        assertEquals(scoreDefinitionHSS.createScore(BigDecimal.valueOf(-147), BigDecimal.valueOf(-258), 
+                BigDecimal.valueOf(-369)), scoreDefinitionHSS.parseScore("-147/-258/-369"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseScoreIllegalArgument() {
+        scoreDefinitionHSS.parseScore("-147");
+    }
+
+    @Test
+    public void feasibleHSS() {
+        assertScoreNotFeasible(
+                scoreDefinitionHSS.createScore(MINUS_FIVE, MINUS_300, MINUS_4000)
+        );
+        assertScoreFeasible(
+                scoreDefinitionHSS.createScore(ZERO, MINUS_300, MINUS_4000),
+                scoreDefinitionHSS.createScore(TWO, MINUS_300, MINUS_4000)
+        );
+    }
+
+    @Test
+    public void addHSS() {
+        assertEquals(scoreDefinitionHSS.createScore(PLUS_19, MINUS_320, ZERO),
+                scoreDefinitionHSS.createScore(PLUS_20, MINUS_20, MINUS_4000).add(
+                        scoreDefinitionHSS.createScore(MINUS_ONE, MINUS_300, PLUS_4000)));
+    }
+
+    @Test
+    public void subtractHSS() {
+        assertEquals(scoreDefinitionHSS.createScore(PLUS_21, PLUS_280, MINUS_8000),
+                scoreDefinitionHSS.createScore(PLUS_20, MINUS_20, MINUS_4000).subtract(
+                        scoreDefinitionHSS.createScore(MINUS_ONE, MINUS_300, PLUS_4000)));
+    }
+
+    @Test
+    public void divideHSS() {
+        assertEquals(scoreDefinitionHSS.createScore(FIVE, MINUS_FIVE, FIVE),
+                scoreDefinitionHSS.createScore(PLUS_25, MINUS_25, PLUS_25).divide(5.0));
+        assertEquals(scoreDefinitionHSS.createScore(FOUR, MINUS_FIVE, FOUR),
+                scoreDefinitionHSS.createScore(PLUS_21, MINUS_21, PLUS_21).divide(5.0));
+        assertEquals(scoreDefinitionHSS.createScore(FOUR, MINUS_FIVE, FOUR),
+                scoreDefinitionHSS.createScore(PLUS_24, MINUS_24, PLUS_24).divide(5.0));
+    }
+
+    @Test
+    @Ignore("The problem of BigDecimal ^ BigDecimal.")
+    public void powerHSS() {
+        // .multiply(1.0) is there to get the proper BigDecimal scale
+        assertEquals(scoreDefinitionHSS.createScore(NINE, PLUS_16, PLUS_25),
+                scoreDefinitionHSS.createScore(THREE, MINUS_FOUR, FIVE).power(2.0));
+        assertEquals(scoreDefinitionHSS.createScore(THREE, FOUR, FIVE),
+                scoreDefinitionHSS.createScore(NINE, PLUS_16, PLUS_25).power(0.5));
+    }
+
+    @Test
+    public void negateHSS() {
+        assertEquals(scoreDefinitionHSS.createScore(MINUS_THREE, FOUR, MINUS_FIVE),
+                scoreDefinitionHSS.createScore(THREE, MINUS_FOUR, FIVE).negate());
+        assertEquals(scoreDefinitionHSS.createScore(THREE, MINUS_FOUR, FIVE),
+                scoreDefinitionHSS.createScore(MINUS_THREE, FOUR, MINUS_FIVE).negate());
+    }
+
+    @Test
+    public void equalsAndHashCodeHSS() {
+        assertScoresEqualsAndHashCode(
+                scoreDefinitionHSS.createScore(MINUS_TEN, MINUS_20, MINUS_30),
+                scoreDefinitionHSS.createScore(MINUS_TEN, MINUS_20, MINUS_30)
+        );
+    }
+
+    @Test
+    public void compareToHSS() {
+        assertScoreCompareToOrder(
+                scoreDefinitionHSS.createScore(MINUS_20, MIN_INTEGER, MIN_INTEGER),
+                scoreDefinitionHSS.createScore(MINUS_20, MIN_INTEGER, MINUS_20),
+                scoreDefinitionHSS.createScore(MINUS_20, MIN_INTEGER, ONE),
+                scoreDefinitionHSS.createScore(MINUS_20, MINUS_300, MINUS_4000),
+                scoreDefinitionHSS.createScore(MINUS_20, MINUS_300, MINUS_300),
+                scoreDefinitionHSS.createScore(MINUS_20, MINUS_300, MINUS_20),
+                scoreDefinitionHSS.createScore(MINUS_20, MINUS_300, PLUS_300),
+                scoreDefinitionHSS.createScore(MINUS_20, MINUS_20, MINUS_300),
+                scoreDefinitionHSS.createScore(MINUS_20, MINUS_20, ZERO),
+                scoreDefinitionHSS.createScore(MINUS_20, MINUS_20, ONE),
+                scoreDefinitionHSS.createScore(MINUS_ONE, MINUS_300, MINUS_4000),
+                scoreDefinitionHSS.createScore(MINUS_ONE, MINUS_300, MINUS_20),
+                scoreDefinitionHSS.createScore(MINUS_ONE, MINUS_20, MINUS_300),
+                scoreDefinitionHSS.createScore(ONE, MIN_INTEGER, MINUS_20),
+                scoreDefinitionHSS.createScore(ONE, MINUS_20, MIN_INTEGER)
+        );
+    }
+
+    private BendableBigDecimalScoreDefinition scoreDefinitionHHSSS = new BendableBigDecimalScoreDefinition(2, 3);
+
+    @Test
+    public void feasibleHHSSS() {
+        assertScoreNotFeasible(
+                scoreDefinitionHHSSS.createScore(MINUS_FIVE, ZERO, MINUS_300, MINUS_4000, MINUS_5000),
+                scoreDefinitionHHSSS.createScore(ZERO, MINUS_FIVE, MINUS_300, MINUS_4000, MINUS_5000)
+        );
+        assertScoreFeasible(
+                scoreDefinitionHHSSS.createScore(ZERO, ZERO, MINUS_300, MINUS_4000, MINUS_5000),
+                scoreDefinitionHHSSS.createScore(ZERO, TWO, MINUS_300, MINUS_4000, MINUS_5000),
+                scoreDefinitionHHSSS.createScore(TWO, ZERO, MINUS_300, MINUS_4000, MINUS_5000)
+        );
+    }
+
+    @Test
+    public void addHHSSS() {
+        assertEquals(scoreDefinitionHHSSS.createScore(PLUS_19, MINUS_320, ZERO, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(PLUS_20, MINUS_20, MINUS_4000, ZERO, ZERO).add(
+                        scoreDefinitionHHSSS.createScore(MINUS_ONE, MINUS_300, PLUS_4000, ZERO, ZERO)));
+    }
+
+    @Test
+    public void subtractHHSSS() {
+        assertEquals(scoreDefinitionHHSSS.createScore(PLUS_21, PLUS_280, MINUS_8000, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(PLUS_20, MINUS_20, MINUS_4000, ZERO, ZERO).subtract(
+                        scoreDefinitionHHSSS.createScore(MINUS_ONE, MINUS_300, PLUS_4000, ZERO, ZERO)));
+    }
+
+    @Test
+    public void divideHHSSS() {
+        assertEquals(scoreDefinitionHHSSS.createScore(FIVE, MINUS_FIVE, FIVE, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(PLUS_25, MINUS_25, PLUS_25, ZERO, ZERO).divide(5.0));
+        assertEquals(scoreDefinitionHHSSS.createScore(FOUR, MINUS_FIVE, FOUR, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(PLUS_21, MINUS_21, PLUS_21, ZERO, ZERO).divide(5.0));
+        assertEquals(scoreDefinitionHHSSS.createScore(FOUR, MINUS_FIVE, FOUR, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(PLUS_24, MINUS_24, PLUS_24, ZERO, ZERO).divide(5.0));
+    }
+
+    @Test
+    @Ignore("The problem of BigDecimal ^ BigDecimal.")
+    public void powerHHSSS() {
+        // .multiply(1.0) is there to get the proper BigDecimal scale
+        assertEquals(scoreDefinitionHHSSS.createScore(NINE, PLUS_16, PLUS_25, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(THREE, MINUS_FOUR, FIVE, ZERO, ZERO).power(2.0));
+        assertEquals(scoreDefinitionHHSSS.createScore(THREE, FOUR, FIVE, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(NINE, PLUS_16, PLUS_25, ZERO, ZERO).power(0.5));
+    }
+
+    @Test
+    public void negateHHSSS() {
+        assertEquals(scoreDefinitionHHSSS.createScore(MINUS_THREE, FOUR, MINUS_FIVE, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(THREE, MINUS_FOUR, FIVE, ZERO, ZERO).negate());
+        assertEquals(scoreDefinitionHHSSS.createScore(THREE, MINUS_FOUR, FIVE, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_THREE, FOUR, MINUS_FIVE, ZERO, ZERO).negate());
+    }
+
+    @Test
+    public void equalsAndHashCodeHHSSS() {
+        assertScoresEqualsAndHashCode(
+                scoreDefinitionHHSSS.createScore(MINUS_TEN, MINUS_20, MINUS_30, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_TEN, MINUS_20, MINUS_30, ZERO, ZERO)
+        );
+    }
+
+    @Test
+    public void compareToHHSSS() {
+        assertScoreCompareToOrder(
+                scoreDefinitionHHSSS.createScore(MINUS_20, MIN_INTEGER, MIN_INTEGER, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_20, MIN_INTEGER, MINUS_20, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_20, MIN_INTEGER, ONE, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_20, MINUS_300, MINUS_4000, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_20, MINUS_300, MINUS_300, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_20, MINUS_300, MINUS_20, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_20, MINUS_300, PLUS_300, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_20, MINUS_20, MINUS_300, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_20, MINUS_20, ZERO, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_20, MINUS_20, ONE, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_ONE, MINUS_300, MINUS_4000, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_ONE, MINUS_300, MINUS_20, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(MINUS_ONE, MINUS_20, MINUS_300, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(ONE, MIN_INTEGER, MINUS_20, ZERO, ZERO),
+                scoreDefinitionHHSSS.createScore(ONE, MINUS_20, MIN_INTEGER, ZERO, ZERO)
+        );
+    }
+
+    @Test
+    public void serializeAndDeserialize() {
+        BendableBigDecimalScore input = scoreDefinitionHSS.createScore(MINUS_FIVE, MINUS_300, MINUS_4000);
+        SerializationTestUtils.serializeAndDeserializeWithAll(input,
+                new SerializationTestUtils.OutputAsserter<BendableBigDecimalScore>() {
+                    public void assertOutput(BendableBigDecimalScore output) {
+                        assertEquals(1, output.getHardLevelsSize());
+                        assertEquals(MINUS_FIVE, output.getHardScore(0));
+                        assertEquals(2, output.getSoftLevelsSize());
+                        assertEquals(MINUS_300, output.getSoftScore(0));
+                        assertEquals(MINUS_4000, output.getSoftScore(1));
+                    }
+                }
+        );
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreDefinitionTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreDefinitionTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.impl.score.buildin.bendablebigdecimal;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BendableBigDecimalScoreDefinitionTest {
+
+    @Test
+    public void getLevelsSize() {
+        assertEquals(2, new BendableBigDecimalScoreDefinition(1, 1).getLevelsSize());
+        assertEquals(7, new BendableBigDecimalScoreDefinition(3, 4).getLevelsSize());
+        assertEquals(7, new BendableBigDecimalScoreDefinition(4, 3).getLevelsSize());
+        assertEquals(5, new BendableBigDecimalScoreDefinition(0, 5).getLevelsSize());
+        assertEquals(5, new BendableBigDecimalScoreDefinition(5, 0).getLevelsSize());
+    }
+
+    @Test
+    public void getFeasibleLevelsSize() {
+        assertEquals(1, new BendableBigDecimalScoreDefinition(1, 1).getFeasibleLevelsSize());
+        assertEquals(3, new BendableBigDecimalScoreDefinition(3, 4).getFeasibleLevelsSize());
+        assertEquals(4, new BendableBigDecimalScoreDefinition(4, 3).getFeasibleLevelsSize());
+        assertEquals(0, new BendableBigDecimalScoreDefinition(0, 5).getFeasibleLevelsSize());
+        assertEquals(5, new BendableBigDecimalScoreDefinition(5, 0).getFeasibleLevelsSize());
+    }
+
+}


### PR DESCRIPTION
This pull request implements `BigDecimal` bendable score.

The alrogithms used are a mix of those from `BendableScore` and `HardSoftBigDecimalScore`. The tests have been adapted from those as well, with two exceptions:
- The `power()` tests have been `@Ignore`d here. The whole problem of "BigDecimal to the power of BigDecimal" deserves a solution, and a skipped test will always remind us of that.
- The `multiply()` tests have been removed. The originals were testing for int result of double multiplication, and that is simply not applicable here.

All the tests are passing.
