### PR TITLE
PLANNER-275 Add Drools score rules for example CheapTime Scheduling

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/domain/CheapTimeSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/domain/CheapTimeSolution.java
@@ -154,6 +154,7 @@ public class CheapTimeSolution extends AbstractPersistable implements Solution<H
         facts.addAll(taskList);
         facts.addAll(taskRequirementList);
         facts.addAll(periodPowerPriceList);
+        facts.add(this);
         // Do not add the planning entity's (taskAssignmentList) because that will be done automatically
         return facts;
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/solver/drools/IdleCost.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/solver/drools/IdleCost.java
@@ -1,0 +1,67 @@
+package org.optaplanner.examples.cheaptime.solver.drools;
+
+import org.apache.commons.lang.builder.CompareToBuilder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.optaplanner.examples.cheaptime.domain.Machine;
+
+public class IdleCost {
+
+    private final Machine machine;
+    private final int activePeriodAfterIdle;
+    private final long cost;
+
+    public IdleCost(Machine machine, int activePeriodAfterIdle, long cost) {
+        this.machine = machine;
+        this.activePeriodAfterIdle = activePeriodAfterIdle;
+        this.cost = cost;
+    }
+
+    public Machine getMachine() {
+        return machine;
+    }
+
+    public int getActivePeriodAfterIdle() {
+        return activePeriodAfterIdle;
+    }
+
+    public long getCost() {
+        return cost;
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o instanceof IdleCost) {
+            IdleCost other = (IdleCost) o;
+            return new EqualsBuilder()
+                    .append(machine, other.machine)
+                    .append(activePeriodAfterIdle, other.activePeriodAfterIdle)
+                    .append(cost, other.cost)
+                    .isEquals();
+        } else {
+            return false;
+        }
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(machine)
+                .append(activePeriodAfterIdle)
+                .append(cost)
+                .toHashCode();
+    }
+
+    public int compareTo(IdleCost other) {
+        return new CompareToBuilder()
+                .append(machine, other.machine)
+                .append(activePeriodAfterIdle, other.activePeriodAfterIdle)
+                .append(cost, other.cost)
+                .toComparison();
+    }
+
+    @Override
+    public String toString() {
+        return "machine = " + machine + ", activePeriodAfterIdle = " + activePeriodAfterIdle + ", cost = " + cost;
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/solver/drools/MachinePeriodPart.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/solver/drools/MachinePeriodPart.java
@@ -1,0 +1,120 @@
+package org.optaplanner.examples.cheaptime.solver.drools;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang.builder.CompareToBuilder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.optaplanner.examples.cheaptime.domain.Machine;
+import org.optaplanner.examples.cheaptime.domain.Task;
+import org.optaplanner.examples.cheaptime.domain.TaskAssignment;
+import org.optaplanner.examples.cheaptime.domain.TaskRequirement;
+
+public class MachinePeriodPart {
+    private final Machine machine;
+    private final int period;
+
+    private boolean active;
+    private int[] resourceAvailableList;
+    private int resourceInShortTotal;
+
+    public MachinePeriodPart(Machine machine, int period, int resourceListSize, List<TaskAssignment> taskAssignmentList) {
+        this.machine = machine;
+        this.period = period;
+
+        active = false;
+
+        resourceAvailableList = new int[resourceListSize];
+        for (int i = 0; i < resourceListSize; i++) {
+            resourceAvailableList[i] = machine.getMachineCapacityList().get(i).getCapacity();
+        }
+
+        for (TaskAssignment taskAssignment : taskAssignmentList) {
+            addTaskAssignment(taskAssignment);
+        }
+
+	    resourceInShortTotal = 0;
+	    for (int resourceAvailable : resourceAvailableList) {
+	        if (resourceAvailable < 0) {
+	            resourceInShortTotal += resourceAvailable;
+	        }
+	    }
+    }
+
+    private void addTaskAssignment(TaskAssignment taskAssignment) {
+        active = true;
+        Task task = taskAssignment.getTask();
+        for (int i = 0; i < resourceAvailableList.length; i++) {
+            TaskRequirement taskRequirement = task.getTaskRequirementList().get(i);
+            resourceAvailableList[i] -=  taskRequirement.getResourceUsage();
+        }
+    }
+
+	public boolean isActive() {
+		return active;
+	}
+
+	public void setActive(boolean active) {
+		this.active = active;
+	}
+
+	public int[] getResourceAvailableList() {
+        return resourceAvailableList;
+    }
+
+    public void setResourceAvailableList(int[] resourceAvailableList) {
+        this.resourceAvailableList = resourceAvailableList;
+    }
+
+    public int getResourceInShortTotal() {
+		return resourceInShortTotal;
+	}
+
+    public Machine getMachine() {
+        return machine;
+    }
+
+    public int getPeriod() {
+        return period;
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o instanceof MachinePeriodPart) {
+            MachinePeriodPart other = (MachinePeriodPart) o;
+            return new EqualsBuilder()
+                    .append(machine, other.machine)
+                    .append(period, other.period)
+                    .append(active, other.active)
+                    .append(resourceAvailableList, other.resourceAvailableList)
+                    .isEquals();
+        } else {
+            return false;
+        }
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(machine)
+                .append(period)
+                .append(active)
+                .append(resourceAvailableList)
+                .toHashCode();
+    }
+
+    public int compareTo(MachinePeriodPart other) {
+        return new CompareToBuilder()
+                .append(machine, other.machine)
+                .append(period, other.period)
+                .append(active, other.active)
+                .append(resourceAvailableList, other.resourceAvailableList)
+                .toComparison();
+    }
+
+    @Override
+    public String toString() {
+        return machine + ", period = " + period + ", active = " + active + ", resourceAvailableList = " + resourceAvailableList;
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/solver/drools/Period.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/solver/drools/Period.java
@@ -1,0 +1,52 @@
+package org.optaplanner.examples.cheaptime.solver.drools;
+
+import org.apache.commons.lang.builder.CompareToBuilder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+public class Period {
+
+    private int period;
+
+    public Period(int period) {
+        this.period = period;
+    }
+
+    public int getPeriod() {
+        return period;
+    }
+
+    public void setPeriod(int period) {
+        this.period = period;
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o instanceof Period) {
+            Period other = (Period) o;
+            return new EqualsBuilder()
+                    .append(period, other.period)
+                    .isEquals();
+        } else {
+            return false;
+        }
+    }
+
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(period)
+                .toHashCode();
+    }
+
+    public int compareTo(Period other) {
+        return new CompareToBuilder()
+                .append(period, other.period)
+                .toComparison();
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(period);
+    }
+}

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/cheaptime/solver/cheapTimeScoreRules.drl
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/cheaptime/solver/cheapTimeScoreRules.drl
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2010 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.cheaptime.solver;
+    dialect "java"
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.optaplanner.core.api.score.buildin.hardmediumsoftlong.HardMediumSoftLongScoreHolder;
+
+import org.optaplanner.examples.cheaptime.domain.CheapTimeSolution;
+import org.optaplanner.examples.cheaptime.domain.Machine;
+import org.optaplanner.examples.cheaptime.domain.MachineCapacity;
+import org.optaplanner.examples.cheaptime.domain.PeriodPowerPrice;
+import org.optaplanner.examples.cheaptime.domain.Task;
+import org.optaplanner.examples.cheaptime.domain.TaskAssignment;
+import org.optaplanner.examples.cheaptime.domain.TaskRequirement;
+import org.optaplanner.examples.cheaptime.solver.CheapTimeCostCalculator;
+import org.optaplanner.examples.cheaptime.solver.drools.IdleCost;
+import org.optaplanner.examples.cheaptime.solver.drools.Period;
+import org.optaplanner.examples.cheaptime.solver.drools.MachinePeriodPart;
+
+global HardMediumSoftLongScoreHolder scoreHolder;
+
+// Setup
+rule "period"
+    salience 3
+    when
+        CheapTimeSolution($globalPeriodRangeFrom : globalPeriodRangeFrom, $globalPeriodRangeTo : globalPeriodRangeTo)
+    then
+        for (int i = $globalPeriodRangeFrom; i < $globalPeriodRangeTo; i++) {
+            insert(new Period(i));
+        }
+end
+
+// Introduce MachinePeriodPart to score efficiently
+rule "machinePeriodPart"
+    salience 2
+    when
+        CheapTimeSolution($resourceList : resourceList)
+        Period($period : period);
+        $machine : Machine()
+        $taskAssignmentList : ArrayList() from collect (
+            TaskAssignment(
+                machine == $machine,
+                startPeriod <= $period,
+                endPeriod > $period)
+        )
+    then
+        insertLogical(new MachinePeriodPart($machine, $period, $resourceList.size(), $taskAssignmentList));
+end
+
+// ############################################################################
+// Hard constraints
+// ############################################################################
+
+// Start time limits: each task must start between its earliest start and latest start limit.
+rule "startTimeLimitsFrom"
+    when
+        $taskAssignment : TaskAssignment($task : task, $startPeriod : startPeriod < $task.startPeriodRangeFrom)
+    then
+        scoreHolder.addHardConstraintMatch(kcontext, $startPeriod - $task.getStartPeriodRangeFrom());
+end
+
+rule "startTimeLimitsTo"
+    when
+        $taskAssignment : TaskAssignment($task : task, $startPeriod : startPeriod >= $task.startPeriodRangeTo)
+    then
+        scoreHolder.addHardConstraintMatch(kcontext, $task.getStartPeriodRangeTo() - $startPeriod);
+end
+
+// Maximum capacity: the maximum capacity for each resource for each machine must not be exceeded.
+rule "maximumCapacity" // resourceInShortTotal is calculated in MachinePeriodPart constructor
+    when
+        MachinePeriodPart($resourceInShortTotal : resourceInShortTotal < 0)
+    then
+        scoreHolder.addHardConstraintMatch(kcontext, $resourceInShortTotal);
+end
+
+// Startup and shutdown: each machine must be active in the periods during which it has assigned tasks.
+//   Between tasks it is allowed to be idle to avoid startup and shutdown costs.
+
+//     -> no rule is required because it's implemented in MachinePeriodPart
+
+// ############################################################################
+// Medium constraints
+// ############################################################################
+
+// Machine power cost: Each active or idle machine consumes power,
+//   which infers a power cost (depending on the power price during that time).
+
+// Machine startup and shutdown cost: Every time a machine starts up or shuts down, an extra cost is inflicted.
+
+rule "calculateIdleCost"
+    salience 1
+    when
+        MachinePeriodPart($machine : machine, $period : period, active == true)
+        exists MachinePeriodPart(machine == $machine, period == $period - 1, active == false)
+        exists MachinePeriodPart(machine == $machine, period < $period - 1, active == true)
+        accumulate (
+            MachinePeriodPart(machine == $machine, $activePeriod : period < $period - 1, active == true);
+            $lastActivePeriod : max($activePeriod)
+        )
+        $idlePeriodPowerPriceList : ArrayList() from collect (
+            PeriodPowerPrice(
+                period > $lastActivePeriod.intValue(),
+                period < $period)
+        )
+    then
+        long idleCost = 0;
+        for (Object obj : $idlePeriodPowerPriceList) {
+            PeriodPowerPrice idlePeriodPowerPrice = (PeriodPowerPrice)obj;
+            idleCost += CheapTimeCostCalculator.multiplyTwoMicros($machine.getPowerConsumptionMicros(), idlePeriodPowerPrice.getPowerPriceMicros());
+        }
+        insertLogical(new IdleCost($machine, $period, idleCost));
+end
+
+rule "machinePowerCostActive"
+    when
+        MachinePeriodPart($machine : machine, $period : period, active == true)
+        $periodPowerPrice : PeriodPowerPrice(period == $period)
+    then
+        scoreHolder.addMediumConstraintMatch(kcontext,
+            - CheapTimeCostCalculator.multiplyTwoMicros($machine.getPowerConsumptionMicros(), $periodPowerPrice.getPowerPriceMicros()));
+end
+
+rule "machinePowerCostOffToActive"
+    when
+        MachinePeriodPart($machine : machine, $period : period, active == true)
+        IdleCost(machine == $machine, activePeriodAfterIdle == $period, $idleCost : cost >= $machine.spinUpDownCostMicros)
+    then
+        scoreHolder.addMediumConstraintMatch(kcontext, - $machine.getSpinUpDownCostMicros());
+end
+
+rule "machinePowerCostIdleToActive"
+    when
+        MachinePeriodPart($machine : machine, $period : period, active == true)
+        IdleCost(machine == $machine, activePeriodAfterIdle == $period, $idleCost : cost < $machine.spinUpDownCostMicros)
+    then
+        scoreHolder.addMediumConstraintMatch(kcontext, - $idleCost);
+end
+
+rule "firstBoot"
+    when
+        MachinePeriodPart($machine : machine, $period : period, active == true)
+        not MachinePeriodPart(machine == $machine, period < $period, active == true);
+    then
+        scoreHolder.addMediumConstraintMatch(kcontext, - $machine.getSpinUpDownCostMicros());
+end
+
+// Task power cost: Each task consumes power too, which infers a power cost (depending on the power price during its time).
+rule "taskPowerCost"
+    when
+        Period($period : period)
+        TaskAssignment(startPeriod <= $period, endPeriod > $period, $task : task)
+        $periodPowerPrice : PeriodPowerPrice(period == $period)
+    then
+        scoreHolder.addMediumConstraintMatch(kcontext,
+            - CheapTimeCostCalculator.multiplyTwoMicros($task.getPowerConsumptionMicros(), $periodPowerPrice.getPowerPriceMicros()));
+end
+
+// ############################################################################
+// Soft constraints
+// ############################################################################
+
+// Start early: prefer starting a task sooner rather than later.
+rule "startEarly"
+    when
+        TaskAssignment($startPeriod : startPeriod != null)
+    then
+        scoreHolder.addSoftConstraintMatch(kcontext, - $startPeriod);
+end

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/cheaptime/solver/cheapTimeSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/cheaptime/solver/cheapTimeSolverConfig.xml
@@ -11,6 +11,7 @@
     <scoreDefinitionType>HARD_MEDIUM_SOFT_LONG</scoreDefinitionType>
     <!--<easyScoreCalculatorClass>org.optaplanner.examples.cheaptime.solver.score.CheapTimeEasyScoreCalculator</easyScoreCalculatorClass>-->
     <incrementalScoreCalculatorClass>org.optaplanner.examples.cheaptime.solver.score.CheapTimeIncrementalScoreCalculator</incrementalScoreCalculatorClass>
+    <!--<scoreDrl>org/optaplanner/examples/cheaptime/solver/cheapTimeScoreRules.drl</scoreDrl>-->
     <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
     <!--<assertionScoreDirectorFactory>-->
       <!--<easyScoreCalculatorClass>org.optaplanner.examples.cheaptime.solver.score.CheapTimeEasyScoreCalculator</easyScoreCalculatorClass>-->


### PR DESCRIPTION
ACC = 670 with sample01.xml

Some points:
- I insert CheapTimeSolution as a fact because only it knows globalPeriodRangeFrom/globalPeriodRangeTo
- I insert Period as a fact to create MachinePeriodPart conveniently. Also it is used in rule "taskPowerCost".
- Rule "machinePeriodPart" seems to be a major bottle-neck but I have no other idea at this moment.
- Note that CheapTimeIncrementalScoreCalculator is used by default. Please uncomment scoreDrl when you test

I'm open to change anything if you suggest in review. Thanks!