### PR TITLE
PLANNER-273 Benchmark report should mention logging level (because that can effect performance)

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/PlannerBenchmarkResult.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/PlannerBenchmarkResult.java
@@ -38,6 +38,8 @@ import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
 import org.optaplanner.core.config.util.ConfigUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents the benchmarks on multiple {@link Solver} configurations on multiple problem instances (data sets).
@@ -53,6 +55,7 @@ public class PlannerBenchmarkResult {
     // If it is an aggregation, many properties can stay null
 
     private Integer availableProcessors = null;
+    private String loggingLevel = null;
     private Long maxMemory = null;
     private String optaPlannerVersion = null;
     private String javaVersion = null;
@@ -105,6 +108,10 @@ public class PlannerBenchmarkResult {
 
     public Integer getAvailableProcessors() {
         return availableProcessors;
+    }
+
+    public String getLoggingLevel() {
+        return loggingLevel;
     }
 
     public Long getMaxMemory() {
@@ -225,6 +232,7 @@ public class PlannerBenchmarkResult {
 
     public void initSystemProperties() {
         availableProcessors = Runtime.getRuntime().availableProcessors();
+        loggingLevel = resolveLoggingLevel();
         maxMemory = Runtime.getRuntime().maxMemory();
         optaPlannerVersion = SolverFactory.class.getPackage().getImplementationVersion();
         if (optaPlannerVersion == null) {
@@ -235,6 +243,23 @@ public class PlannerBenchmarkResult {
                 + " (" + System.getProperty("java.vm.vendor") + ")";
         operatingSystem = System.getProperty("os.name") + " " + System.getProperty("os.arch")
                 + " " + System.getProperty("os.version");
+    }
+
+    private String resolveLoggingLevel() {
+        Logger logger = LoggerFactory.getLogger("org.optaplanner");
+        if (logger.isTraceEnabled()) {
+            return "trace";
+        } else if (logger.isDebugEnabled()) {
+            return "debug";
+        } else if (logger.isInfoEnabled()) {
+            return "info";
+        } else if (logger.isWarnEnabled()) {
+            return "warn";
+        } else if (logger.isErrorEnabled()) {
+            return "error";
+        } else {
+            throw new IllegalStateException("Logging level for category (org.optaplanner) cannot be determined.");
+        }
     }
 
     public void accumulateResults(BenchmarkReport benchmarkReport) {
@@ -377,6 +402,7 @@ public class PlannerBenchmarkResult {
                     newResult = new PlannerBenchmarkResult();
                     newResult.setAggregation(true);
                     newResult.availableProcessors = oldResult.availableProcessors;
+                    newResult.loggingLevel = oldResult.loggingLevel;
                     newResult.maxMemory = oldResult.maxMemory;
                     newResult.optaPlannerVersion = oldResult.optaPlannerVersion;
                     newResult.javaVersion = oldResult.javaVersion;
@@ -394,6 +420,8 @@ public class PlannerBenchmarkResult {
                             newResult.availableProcessors, oldResult.availableProcessors);
                     newResult.maxMemory = ConfigUtils.mergeProperty(
                             newResult.maxMemory, oldResult.maxMemory);
+                    newResult.loggingLevel = ConfigUtils.mergeProperty(
+                            newResult.loggingLevel, oldResult.loggingLevel);
                     newResult.optaPlannerVersion = ConfigUtils.mergeProperty(
                             newResult.optaPlannerVersion, oldResult.optaPlannerVersion);
                     newResult.javaVersion = ConfigUtils.mergeProperty(

--- a/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
+++ b/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
@@ -614,6 +614,10 @@
                         <td>${benchmarkReport.plannerBenchmarkResult.benchmarkTimeMillisSpent!"Differs"} ms</td>
                     </tr>
                     <tr>
+                        <th>Logging level</th>
+                        <td>${benchmarkReport.plannerBenchmarkResult.loggingLevel!"Differs"}</td>
+                    </tr>
+                    <tr>
                         <th>VM max memory (as in -Xmx but lower)</th>
                         <td>${(benchmarkReport.plannerBenchmarkResult.maxMemory?string.number)!"Differs"} bytes</td>
                     </tr>


### PR DESCRIPTION
* As SLF4J doesn't expose log level, manual resolving needs to be done
* Level resolved for the most general category (org.optaplanner), as sub-categories can define their own logging levels.