### PR TITLE
Added feature that allows loading Drools rules from a KJAR via kie-ci (i...

### DIFF
--- a/optaplanner-core/pom.xml
+++ b/optaplanner-core/pom.xml
@@ -72,6 +72,13 @@
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
     </dependency>
+    <!-- Test -->
+    <dependency>
+    	<groupId>org.drools</groupId>
+    	<artifactId>drools-compiler</artifactId>
+    	<type>test-jar</type>
+    	<scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -88,6 +88,8 @@ public class ScoreDirectorFactoryConfig {
     protected List<File> scoreDrlFileList = null;
     @XStreamConverter(value = KeyAsElementMapConverter.class)
     protected Map<String, String> kieBaseConfigurationProperties = null;
+    @XStreamAlias("scoreKJarReleaseId")
+	protected ScoreKJarReleaseIdConfig scoreKJarReleaseIdConfig;
 
     protected String initializingScoreTrend = null;
 
@@ -361,7 +363,22 @@ public class ScoreDirectorFactoryConfig {
                 throw new IllegalArgumentException("If kieBase is not null, the kieBaseConfigurationProperties ("
                         + kieBaseConfigurationProperties + ") must be null.");
             }
+            if(scoreKJarReleaseIdConfig != null) {
+            	throw new IllegalArgumentException("If kieBase is not null, the scoreKJarReleaseId ("
+                        + scoreKJarReleaseIdConfig + ") must be null.");
+            }
             return new DroolsScoreDirectorFactory(kieBase);
+        } else if(scoreKJarReleaseIdConfig != null) {
+        	//Loading the rules from a KJAR identified by a GAV (i.e. KJAR ReleaseId).
+        	if (!ConfigUtils.isEmptyCollection(scoreDrlList) || !ConfigUtils.isEmptyCollection(scoreDrlFileList)) {
+                throw new IllegalArgumentException("If scoreKJarReleaseId is not null, the scoreDrlList (" + scoreDrlList
+                        + ") and the scoreDrlFileList (" + scoreDrlFileList + ") must be empty.");
+            }
+            if (kieBaseConfigurationProperties != null) {
+                throw new IllegalArgumentException("If scoreKJarReleaseId is not null, the kieBaseConfigurationProperties ("
+                        + kieBaseConfigurationProperties + ") must be null.");
+            }
+        	return scoreKJarReleaseIdConfig.build();
         } else if (!ConfigUtils.isEmptyCollection(scoreDrlList) || !ConfigUtils.isEmptyCollection(scoreDrlFileList)) {
             KieServices kieServices = KieServices.Factory.get();
             KieResources kieResources = kieServices.getResources();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreKJarReleaseIdConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreKJarReleaseIdConfig.java
@@ -1,0 +1,65 @@
+package org.optaplanner.core.config.score.director;
+
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.runtime.KieContainer;
+import org.optaplanner.core.impl.score.director.drools.DroolsScoreDirectorFactory;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Config class which holds the configuration of the Drools KJAR {@link ReleaseId} (Maven GAV).
+ * <p/>
+ * Provides a builder method to build a {@link DroolsScoreDirectorFactory} directly from a config instance.
+ * 
+ * @author <a href="mailto:duncan.doyle@redhat.com">Duncan Doyle</a>
+ */
+@XStreamAlias("scoreKJarReleaseId")
+public class ScoreKJarReleaseIdConfig {
+
+	@XStreamAlias("groupId")
+	private String groupId;
+	
+	@XStreamAlias("artifactId")
+	private String artifactId;
+	
+	@XStreamAlias("version")
+	private String version;
+
+	public String getGroupId() {
+		return groupId;
+	}
+
+	public void setGroupId(String groupId) {
+		this.groupId = groupId;
+	}
+
+	public String getArtifactId() {
+		return artifactId;
+	}
+
+	public void setArtifactId(String artifactId) {
+		this.artifactId = artifactId;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+	
+	// ************************************************************************
+    // Builder methods
+    // ************************************************************************
+	public DroolsScoreDirectorFactory build() {
+		KieServices kieServices = KieServices.Factory.get();
+		ReleaseId releaseId = kieServices.newReleaseId(getGroupId(), getArtifactId(), getVersion());
+		KieContainer kieContainer = kieServices.newKieContainer(releaseId);
+		KieBase kieBase = kieContainer.getKieBase();
+		return new DroolsScoreDirectorFactory(kieBase);
+	}
+	
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/score/director/ScoreKJarReleaseIdConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/score/director/ScoreKJarReleaseIdConfigTest.java
@@ -25,7 +25,7 @@ public class ScoreKJarReleaseIdConfigTest extends CommonTestMethodBase {
 	private static KieServices kieServices;
 	
 	//Simple rule that doesn't really do anything. Just for test.
-		private static String drlOne = "package org.optaplanner.test;\n " +
+	private static String drlOne = "package org.optaplanner.test;\n " +
 		
 				"import org.optaplanner.core.api.score.buildin.simple.SimpleScoreHolder;\n" +
 				"import java.lang.String;\n" +
@@ -53,7 +53,6 @@ public class ScoreKJarReleaseIdConfigTest extends CommonTestMethodBase {
 		createAndDeployJar(kieServices, KMODULE_CONTENT, releaseId, drlOneResource);
 	}
 	
-	
 	@Test
 	public void testKJarAvailable() {
 		
@@ -76,7 +75,7 @@ public class ScoreKJarReleaseIdConfigTest extends CommonTestMethodBase {
 		assertEquals("Expected rule with this specific name in KieBase.", "SimpleConstraintRule", ruleNames.get(0));
 	}
 	
-	@Test
+	@Test(expected=RuntimeException.class)
 	public void testKJarNotAvailable() {
 		boolean caughtException = false;
 		ScoreKJarReleaseIdConfig config = new ScoreKJarReleaseIdConfig();
@@ -84,13 +83,8 @@ public class ScoreKJarReleaseIdConfigTest extends CommonTestMethodBase {
 		config.setArtifactId(artifactId);
 		//Use a non-ex
 		config.setVersion("1.0.1");
-		try {
-			DroolsScoreDirectorFactory scoreDirectorFactory = config.build();
-		} catch (RuntimeException re) {
-			caughtException = true;
-		}
-		assertEquals("Expected exception when trying to load a KJAR which doesn't exist.", true, caughtException);
+		
+		DroolsScoreDirectorFactory scoreDirectorFactory = config.build();
 	}
-	
 
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/score/director/ScoreKJarReleaseIdConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/score/director/ScoreKJarReleaseIdConfigTest.java
@@ -81,7 +81,7 @@ public class ScoreKJarReleaseIdConfigTest extends CommonTestMethodBase {
 		ScoreKJarReleaseIdConfig config = new ScoreKJarReleaseIdConfig();
 		config.setGroupId(groupId);
 		config.setArtifactId(artifactId);
-		//Use a non-ex
+		//Use a non-existing version.
 		config.setVersion("1.0.1");
 		
 		DroolsScoreDirectorFactory scoreDirectorFactory = config.build();

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/score/director/ScoreKJarReleaseIdConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/score/director/ScoreKJarReleaseIdConfigTest.java
@@ -1,0 +1,96 @@
+package org.optaplanner.core.config.score.director;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.drools.compiler.CommonTestMethodBase;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.kie.api.KieServices;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.definition.KiePackage;
+import org.kie.api.definition.rule.Rule;
+import org.kie.api.io.Resource;
+import org.optaplanner.core.impl.score.director.drools.DroolsScoreDirectorFactory;
+
+public class ScoreKJarReleaseIdConfigTest extends CommonTestMethodBase {
+	
+	private static final String KMODULE_CONTENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+			+ "<kmodule xmlns=\"http://jboss.org/kie/6.0.0/kmodule\">"
+			+ "</kmodule>";
+	
+	private static KieServices kieServices;
+	
+	//Simple rule that doesn't really do anything. Just for test.
+		private static String drlOne = "package org.optaplanner.test;\n " +
+		
+				"import org.optaplanner.core.api.score.buildin.simple.SimpleScoreHolder;\n" +
+				"import java.lang.String;\n" +
+				
+				"global SimpleScoreHolder scoreHolder;\n" +
+				
+				"rule \"SimpleConstraintRule\"\n" + 
+				"when\n" +
+					"$s:String(this==\"MY_CODE\")\n" + 
+				"then\n" +
+					"scoreHolder.addConstraintMatch(kcontext, -1);\n" +
+				"end\n";
+		
+	private static String groupId = "org.optaplanner.rules.test";
+	private static String artifactId = "test-rules";
+	private static String version = "1.0.0";
+	private static ReleaseId releaseId;
+	
+	@BeforeClass
+	public static void setupTest() {
+		kieServices = KieServices.Factory.get();
+		releaseId  = kieServices.newReleaseId(groupId, artifactId, version);
+		Resource drlOneResource = kieServices.getResources().newReaderResource(new StringReader(drlOne));
+		drlOneResource.setTargetPath("rules.drl");
+		createAndDeployJar(kieServices, KMODULE_CONTENT, releaseId, drlOneResource);
+	}
+	
+	
+	@Test
+	public void testKJarAvailable() {
+		
+		ScoreKJarReleaseIdConfig config = new ScoreKJarReleaseIdConfig();
+		config.setGroupId(groupId);
+		config.setArtifactId(artifactId);
+		config.setVersion(version);
+		DroolsScoreDirectorFactory scoreDirectorFactory = config.build();
+		
+		KieBase kieBase = scoreDirectorFactory.getKieBase();
+		List<String> ruleNames = new ArrayList<String>();
+		Collection<KiePackage> kiePackages = kieBase.getKiePackages();
+		for(KiePackage nextKiePackage: kiePackages) {
+			Collection<Rule> rules = nextKiePackage.getRules();
+			for(Rule nextRule: rules) {
+				ruleNames.add(nextRule.getName());
+			}
+		}
+		assertEquals("Expected only 1 rule in KieBase.", 1, ruleNames.size());
+		assertEquals("Expected rule with this specific name in KieBase.", "SimpleConstraintRule", ruleNames.get(0));
+	}
+	
+	@Test
+	public void testKJarNotAvailable() {
+		boolean caughtException = false;
+		ScoreKJarReleaseIdConfig config = new ScoreKJarReleaseIdConfig();
+		config.setGroupId(groupId);
+		config.setArtifactId(artifactId);
+		//Use a non-ex
+		config.setVersion("1.0.1");
+		try {
+			DroolsScoreDirectorFactory scoreDirectorFactory = config.build();
+		} catch (RuntimeException re) {
+			caughtException = true;
+		}
+		assertEquals("Expected exception when trying to load a KJAR which doesn't exist.", true, caughtException);
+	}
+	
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/config/score/director/ScoreKJarReleaseIdConfigTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/config/score/director/ScoreKJarReleaseIdConfigTest.java
@@ -77,7 +77,6 @@ public class ScoreKJarReleaseIdConfigTest extends CommonTestMethodBase {
 	
 	@Test(expected=RuntimeException.class)
 	public void testKJarNotAvailable() {
-		boolean caughtException = false;
 		ScoreKJarReleaseIdConfig config = new ScoreKJarReleaseIdConfig();
 		config.setGroupId(groupId);
 		config.setArtifactId(artifactId);


### PR DESCRIPTION
....e. Maven GAV).

Geoffrey, as discussed, an initial version of the feature that allows one to load score rules from a Drools KJAR via Maven (kie-ci and Maven GAV). Including unit-tests ;-)

To use it in, for example, the cloud-balancing example, you would need to externalize the score rules in a KJAR and reference the KJAR from the solver config like this:

```xml
<!-- Score configuration -->
<scoreDirectorFactory>
    <scoreDefinitionType>HARD_SOFT</scoreDefinitionType>
    <scoreKJarReleaseId>
    	<groupId>org.optaplanner.example.cloudbalancing</groupId>
    	<artifactId>CloudBalancingRules</artifactId>
    	<version>1.0.0</version>
    </scoreKJarReleaseId>	
    <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
</scoreDirectorFactory>
```