### PR TITLE
Daemon Mode Bug fixed 

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
@@ -183,12 +183,11 @@ public class DefaultSolver implements Solver {
     public void outerSolvingStarted(DefaultSolverScope solverScope) {
         solving.set(true);
         basicPlumbingTermination.resetTerminateEarly();
-        solverScope.setStartingSystemTimeMillis(System.currentTimeMillis());
-        solverScope.setEndingSystemTimeMillis(null);
-        solverScope.setStartingSolverCount(0);
+        solverScope.reset();
     }
 
     public void solvingStarted(DefaultSolverScope solverScope) {
+        solverScope.reset();
         solverScope.setWorkingRandom(randomFactory.createRandom());
         solverScope.setScoreDirector(scoreDirectorFactory.buildScoreDirector(constraintMatchEnabledPreference));
         solverScope.setWorkingSolutionFromBestSolution();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolver.java
@@ -183,7 +183,6 @@ public class DefaultSolver implements Solver {
     public void outerSolvingStarted(DefaultSolverScope solverScope) {
         solving.set(true);
         basicPlumbingTermination.resetTerminateEarly();
-        solverScope.reset();
     }
 
     public void solvingStarted(DefaultSolverScope solverScope) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/DefaultSolverScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/DefaultSolverScope.java
@@ -186,6 +186,12 @@ public class DefaultSolverScope {
     // Calculated methods
     // ************************************************************************
 
+   public void reset(){
+        setStartingSystemTimeMillis(System.currentTimeMillis());
+        setEndingSystemTimeMillis(null);
+        setStartingSolverCount(0);
+    }
+    
     public boolean isBestSolutionInitialized() {
         return bestUninitializedVariableCount == 0;
     }


### PR DESCRIPTION
The solverScope time parameters do not reset when solver starts again after a time termination. 
It is fixed now. See the changes in the CloudBalancingDaemon Test. 

Detailed description can be found here.
https://groups.google.com/forum/#!topic/optaplanner-dev/Rj1d2rGXa_k