### PR TITLE
Allow the Benchmarking results page to display a schedule with up to …

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
@@ -69,7 +69,7 @@ import org.optaplanner.core.impl.score.ScoreUtils;
 
 public class BenchmarkReport {
 
-    public static final int CHARTED_SCORE_LEVEL_SIZE = 5;
+    public static final int CHARTED_SCORE_LEVEL_SIZE = 15;
 
     private final PlannerBenchmarkResult plannerBenchmarkResult;
 


### PR DESCRIPTION
…15 different score levels. (Limited for visualization reasons)

Discussion can be viewed [here.](https://groups.google.com/forum/#!topic/optaplanner-dev/Lw2GZCC2-Oc)