### PR TITLE
PLANNER-333: Added information about initialization of single benchmark solutions to report

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SingleBenchmarkRunner.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SingleBenchmarkRunner.java
@@ -89,6 +89,7 @@ public class SingleBenchmarkRunner implements Callable<SingleBenchmarkRunner> {
                 solutionDescriptor.getVariableCount(outputSolution),
                 solutionDescriptor.getProblemScale(outputSolution));
         singleBenchmarkResult.setScore(outputSolution.getScore());
+        singleBenchmarkResult.setInitialized(solverScope.isBestSolutionInitialized());
         singleBenchmarkResult.setTimeMillisSpent(timeMillisSpent);
         singleBenchmarkResult.setCalculateCount(solverScope.getCalculateCount());
 

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SingleBenchmarkResult.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SingleBenchmarkResult.java
@@ -55,6 +55,7 @@ public class SingleBenchmarkResult {
     private Long usedMemoryAfterInputSolution = null;
 
     private Boolean succeeded = null;
+    private Boolean initialized = null;
     private Score score = null;
     private long timeMillisSpent = -1L;
     private long calculateCount = -1L;
@@ -134,6 +135,14 @@ public class SingleBenchmarkResult {
         this.succeeded = succeeded;
     }
 
+    public Boolean getInitialized() {
+        return initialized;
+    }
+
+    public void setInitialized(Boolean initialized) {
+        this.initialized = initialized;
+    }
+
     public Score getScore() {
         return score;
     }
@@ -199,6 +208,10 @@ public class SingleBenchmarkResult {
 
     public boolean isSuccess() {
         return succeeded != null && succeeded.booleanValue();
+    }
+
+    public boolean isInitialized() {
+        return initialized != null && initialized.booleanValue();
     }
 
     public boolean isFailure() {

--- a/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
+++ b/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
@@ -27,15 +27,16 @@
 <#macro addSingleRankingBadge singleBenchmarkResult>
     <#if !singleBenchmarkResult.ranking??>
     <span class="badge badge-important">F</span>
+    <#elseif singleBenchmarkResult.winner>
+    <span class="badge badge-success">${singleBenchmarkResult.ranking}</span>
     <#else>
-        <#if singleBenchmarkResult.winner>
-        <span class="badge badge-success">${singleBenchmarkResult.ranking}</span>
-        <#else>
-        <span class="badge">${singleBenchmarkResult.ranking}</span>
-        </#if>
-        <#if !singleBenchmarkResult.scoreFeasible>
-        <span class="badge badge-warning">!</span>
-        </#if>
+    <span class="badge">${singleBenchmarkResult.ranking}</span>
+    </#if>
+
+    <#if !singleBenchmarkResult.initialized>
+    <span class="badge badge-important">!</span>
+    <#elseif !singleBenchmarkResult.scoreFeasible>
+    <span class="badge badge-warning">!</span>
     </#if>
 </#macro>
 <#macro addScoreLevelChartList chartFileList idPrefix>


### PR DESCRIPTION
The report now displays a red '!' in case the single benchmark best solution was uninitialized.