### PR TITLE
PLANNER-334: Added tooltips to explain uninitialized/infeasible/failed benchmark badges in report

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SingleBenchmarkRunner.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SingleBenchmarkRunner.java
@@ -89,6 +89,7 @@ public class SingleBenchmarkRunner implements Callable<SingleBenchmarkRunner> {
                 solutionDescriptor.getVariableCount(outputSolution),
                 solutionDescriptor.getProblemScale(outputSolution));
         singleBenchmarkResult.setScore(outputSolution.getScore());
+        singleBenchmarkResult.setInitialized(solverScope.isBestSolutionInitialized());
         singleBenchmarkResult.setTimeMillisSpent(timeMillisSpent);
         singleBenchmarkResult.setCalculateCount(solverScope.getCalculateCount());
 

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SingleBenchmarkResult.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SingleBenchmarkResult.java
@@ -55,6 +55,7 @@ public class SingleBenchmarkResult {
     private Long usedMemoryAfterInputSolution = null;
 
     private Boolean succeeded = null;
+    private Boolean initialized = null;
     private Score score = null;
     private long timeMillisSpent = -1L;
     private long calculateCount = -1L;
@@ -134,6 +135,14 @@ public class SingleBenchmarkResult {
         this.succeeded = succeeded;
     }
 
+    public Boolean getInitialized() {
+        return initialized;
+    }
+
+    public void setInitialized(Boolean initialized) {
+        this.initialized = initialized;
+    }
+
     public Score getScore() {
         return score;
     }
@@ -199,6 +208,10 @@ public class SingleBenchmarkResult {
 
     public boolean isSuccess() {
         return succeeded != null && succeeded.booleanValue();
+    }
+
+    public boolean isInitialized() {
+        return initialized != null && initialized.booleanValue();
     }
 
     public boolean isFailure() {

--- a/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
+++ b/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
@@ -27,15 +27,16 @@
 <#macro addSingleRankingBadge singleBenchmarkResult>
     <#if !singleBenchmarkResult.ranking??>
     <span class="badge badge-important">F</span>
+    <#elseif singleBenchmarkResult.winner>
+    <span class="badge badge-success">${singleBenchmarkResult.ranking}</span>
     <#else>
-        <#if singleBenchmarkResult.winner>
-        <span class="badge badge-success">${singleBenchmarkResult.ranking}</span>
-        <#else>
-        <span class="badge">${singleBenchmarkResult.ranking}</span>
-        </#if>
-        <#if !singleBenchmarkResult.scoreFeasible>
-        <span class="badge badge-warning">!</span>
-        </#if>
+    <span class="badge">${singleBenchmarkResult.ranking}</span>
+    </#if>
+
+    <#if !singleBenchmarkResult.initialized>
+    <span class="badge badge-important">!</span>
+    <#elseif !singleBenchmarkResult.scoreFeasible>
+    <span class="badge badge-warning">!</span>
     </#if>
 </#macro>
 <#macro addScoreLevelChartList chartFileList idPrefix>

--- a/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
+++ b/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
@@ -17,7 +17,7 @@
 </head>
 <#macro addSolverRankingBadge solverBenchmarkResult>
     <#if !solverBenchmarkResult.ranking??>
-    <span class="badge badge-important">F</span>
+    <span class="badge badge-important" data-toggle="tooltip" title="Failed benchmark">F</span>
     <#elseif solverBenchmarkResult.favorite>
     <span class="badge badge-success">${solverBenchmarkResult.ranking}</span>
     <#else>
@@ -26,7 +26,7 @@
 </#macro>
 <#macro addSingleRankingBadge singleBenchmarkResult>
     <#if !singleBenchmarkResult.ranking??>
-    <span class="badge badge-important">F</span>
+    <span class="badge badge-important" data-toggle="tooltip" title="Failed benchmark">F</span>
     <#elseif singleBenchmarkResult.winner>
     <span class="badge badge-success">${singleBenchmarkResult.ranking}</span>
     <#else>
@@ -34,9 +34,9 @@
     </#if>
 
     <#if !singleBenchmarkResult.initialized>
-    <span class="badge badge-important">!</span>
+    <span class="badge badge-important" data-toggle="tooltip" title="Uninitialized solution">!</span>
     <#elseif !singleBenchmarkResult.scoreFeasible>
-    <span class="badge badge-warning">!</span>
+    <span class="badge badge-warning" data-toggle="tooltip" title="Infeasible score">!</span>
     </#if>
 </#macro>
 <#macro addScoreLevelChartList chartFileList idPrefix>
@@ -651,5 +651,10 @@
 <script src="twitterbootstrap/js/jquery.js"></script>
 <script src="twitterbootstrap/js/bootstrap.js"></script>
 <script src="twitterbootstrap/js/prettify.js"></script>
+<script>
+$(function () {
+    $('[data-toggle="tooltip"]').tooltip()
+})
+</script>
 </body>
 </html>


### PR DESCRIPTION
**NOTE: Merge only after #105**

* Tested on Firefox and Chrome
* Works even without javascript enabled (tooltips then look like standard html tooltips)