### PR TITLE
PLANNER-396: define classpath for examples using wildcards

### DIFF
--- a/optaplanner-distribution/src/main/assembly/scripts/runExamples.bat
+++ b/optaplanner-distribution/src/main/assembly/scripts/runExamples.bat
@@ -4,8 +4,7 @@ setLocal enableExtensions enableDelayedExpansion
 rem Most examples run (potentially slower) with max heap of 128 MB (so -Xmx128m), but 1 example's dataset requires 1.5 GB
 set "jvmOptions=-Xms256m -Xmx1536m -Dorg.optaplanner.examples.dataDir=sources/data/"
 set "mainClass=org.optaplanner.examples.app.OptaPlannerExamplesApp"
-set "mainClasspath="
-for %%i in (binaries\*.jar) do (set "mainClasspath=!mainClasspath!;%%i")
+set "mainClasspath=binaries/*;../binaries/*"
 
 echo Usage: runExamples.bat
 echo Notes:

--- a/optaplanner-distribution/src/main/assembly/scripts/runExamples.sh
+++ b/optaplanner-distribution/src/main/assembly/scripts/runExamples.sh
@@ -6,10 +6,7 @@ cd `dirname $0`
 # Most examples run (potentially slower) with max heap of 128 MB (so -Xmx128m), but 1 example's dataset requires 1.5 GB
 jvmOptions="-Xms256m -Xmx1536m -Dorg.optaplanner.examples.dataDir=sources/data/"
 mainClass=org.optaplanner.examples.app.OptaPlannerExamplesApp
-mainClasspath=
-for i in binaries/*.jar; do
-  mainClasspath=${mainClasspath}:$i
-done
+mainClasspath="binaries/*:../binaries/*"
 
 echo "Usage: ./runExamples.sh"
 echo "Notes:"

--- a/optaplanner-examples/pom.xml
+++ b/optaplanner-examples/pom.xml
@@ -43,19 +43,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <configuration>
-            <archive>
-              <manifest>
-                <!-- Needed for runExamples.sh and runExamples.bat -->
-                <addClasspath>true</addClasspath>
-                <classpathPrefix>../../binaries/</classpathPrefix>
-              </manifest>
-            </archive>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <!-- WARNING: This configuration must be run with "mvn exec:java" not "mvn exec:exec". -->


### PR DESCRIPTION
 * tested on Linux and Windows Server 2012 R2

 * works even with long base directory
   (tried with one that had more than 160 chars)