### PR TITLE
Added modules to the maven-checkstyle-plugin

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/BenchmarkAggregatorFrame.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/BenchmarkAggregatorFrame.java
@@ -386,7 +386,7 @@ public class BenchmarkAggregatorFrame extends JFrame {
             final Object benchmarkResult = mixedCheckBox.getBenchmarkResult();
 
             JPanel mainPanel = new JPanel(new BorderLayout());
-            String benchmarkResultTextFieldText = null; 
+            String benchmarkResultTextFieldText = null;
             if (benchmarkResult instanceof SolverBenchmarkResult) {
                 benchmarkResultTextFieldText = solverBenchmarkResultNameMapping.get(benchmarkResult);
             }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/CheckBoxTree.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/CheckBoxTree.java
@@ -96,7 +96,7 @@ public class CheckBoxTree extends JTree {
         checkBox.setStatus(newStatus);
         selectChildren(currentNode, newStatus);
         TreeNode[] ancestorNodes = currentNode.getPath();
-        // examine ancestors, don't lose track of most recent changes - bottom-up approach 
+        // examine ancestors, don't lose track of most recent changes - bottom-up approach
         for (int i = ancestorNodes.length - 2; i >= 0; i--) {
             DefaultMutableTreeNode ancestorNode = (DefaultMutableTreeNode) ancestorNodes[i];
             MixedCheckBox ancestorCheckbox = (MixedCheckBox) ancestorNode.getUserObject();

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/MixedCheckBox.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/swingui/MixedCheckBox.java
@@ -81,7 +81,7 @@ public class MixedCheckBox extends JCheckBox {
     private static class MixedCheckBoxModel extends ToggleButtonModel {
 
         private MixedCheckBoxStatus getStatus() {
-            return isSelected() ? (isArmed() ? MixedCheckBoxStatus.MIXED : MixedCheckBoxStatus.CHECKED) : MixedCheckBoxStatus.UNCHECKED; 
+            return isSelected() ? (isArmed() ? MixedCheckBoxStatus.MIXED : MixedCheckBoxStatus.CHECKED) : MixedCheckBoxStatus.UNCHECKED;
         }
 
         private void setStatus(MixedCheckBoxStatus status) {
@@ -98,7 +98,7 @@ public class MixedCheckBox extends JCheckBox {
                 setArmed(true);
                 setPressed(true);
             } else {
-                throw new IllegalArgumentException("Invalid argument (" 
+                throw new IllegalArgumentException("Invalid argument ("
                         + status + ") supplied.");
             }
         }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/ranking/SolverRankingWeightFactory.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/ranking/SolverRankingWeightFactory.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.optaplanner.benchmark.impl.result.SolverBenchmarkResult;
 
 /**
- * Defines an interface for classes that will be used to rank solver benchmarks 
+ * Defines an interface for classes that will be used to rank solver benchmarks
  * in order of their respective performance.
  */
 public interface SolverRankingWeightFactory {

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemStatistic.java
@@ -39,7 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * 1 statistic of {@link ProblemBenchmarkResult}
+ * 1 statistic of {@link ProblemBenchmarkResult}.
  */
 @XStreamInclude({
         BestScoreProblemStatistic.class,

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/PureSingleStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/PureSingleStatistic.java
@@ -30,7 +30,7 @@ import org.optaplanner.benchmark.impl.statistic.single.pickedmovetypebestscore.P
 import org.optaplanner.benchmark.impl.statistic.single.pickedmovetypestepscore.PickedMoveTypeStepScoreDiffSingleStatistic;
 
 /**
- * 1 statistic of {@link SingleBenchmarkResult}
+ * 1 statistic of {@link SingleBenchmarkResult}.
  */
 @XStreamInclude({
         ConstraintMatchTotalBestScoreSingleStatistic.class,

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/SingleStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/SingleStatistic.java
@@ -42,7 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * 1 statistic of {@link SingleBenchmarkResult}
+ * 1 statistic of {@link SingleBenchmarkResult}.
  */
 @XStreamInclude({
         PureSingleStatistic.class

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/StatisticPoint.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/StatisticPoint.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Implementations must be immutable
+ * Implementations must be immutable.
  */
 public abstract class StatisticPoint {
 

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/memoryuse/MemoryUseSingleStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/memoryuse/MemoryUseSingleStatistic.java
@@ -58,7 +58,7 @@ public class MemoryUseSingleStatistic extends ProblemBasedSingleStatistic<Memory
     public void close(Solver solver) {
         ((DefaultSolver) solver).removePhaseLifecycleListener(listener);
     }
-    
+
     private class MemoryUseSingleStatisticListener extends PhaseLifecycleListenerAdapter {
 
         private long nextTimeMillisThreshold = timeMillisThresholdInterval;

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/movecountperstep/MoveCountPerStepProblemStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/movecountperstep/MoveCountPerStepProblemStatistic.java
@@ -76,7 +76,7 @@ public class MoveCountPerStepProblemStatistic extends ProblemStatistic {
         XYPlot plot = new XYPlot(null, xAxis, yAxis, null);
         DrawingSupplier drawingSupplier = new DefaultDrawingSupplier();
         plot.setOrientation(PlotOrientation.VERTICAL);
-        
+
         int seriesIndex = 0;
         for (SingleBenchmarkResult singleBenchmarkResult : problemBenchmarkResult.getSingleBenchmarkResultList()) {
             XYSeries acceptedSeries = new XYSeries(

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/movecountperstep/MoveCountPerStepSingleStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/movecountperstep/MoveCountPerStepSingleStatistic.java
@@ -48,7 +48,7 @@ public class MoveCountPerStepSingleStatistic extends ProblemBasedSingleStatistic
     public void close(Solver solver) {
         ((DefaultSolver) solver).removePhaseLifecycleListener(listener);
     }
-    
+
     private class MoveCountPerStepSingleStatisticListener extends PhaseLifecycleListenerAdapter {
 
         @Override
@@ -56,8 +56,8 @@ public class MoveCountPerStepSingleStatistic extends ProblemBasedSingleStatistic
             if (stepScope instanceof LocalSearchStepScope) {
                 localSearchStepEnded((LocalSearchStepScope) stepScope);
             }
-        }        
-        
+        }
+
         private void localSearchStepEnded(LocalSearchStepScope stepScope) {
             long timeMillisSpent = stepScope.getPhaseScope().calculateSolverTimeMillisSpent();
             pointList.add(new MoveCountPerStepStatisticPoint(timeMillisSpent,

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/movecountperstep/MoveCountPerStepStatisticPoint.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/movecountperstep/MoveCountPerStepStatisticPoint.java
@@ -42,5 +42,5 @@ public class MoveCountPerStepStatisticPoint extends StatisticPoint {
         return buildCsvLineWithLongs(timeMillisSpent, moveCountPerStepMeasurement.getAcceptedMoveCount(),
                 moveCountPerStepMeasurement.getSelectedMoveCount());
     }
-   
+
 }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/single/constraintmatchtotalstepscore/ConstraintMatchTotalStepScoreSingleStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/single/constraintmatchtotalstepscore/ConstraintMatchTotalStepScoreSingleStatistic.java
@@ -106,7 +106,7 @@ public class ConstraintMatchTotalStepScoreSingleStatistic extends PureSingleStat
         }
 
         private void localSearchStepEnded(LocalSearchStepScope stepScope) {
-            if (constraintMatchEnabled ) {
+            if (constraintMatchEnabled) {
                 long timeMillisSpent = stepScope.getPhaseScope().calculateSolverTimeMillisSpent();
                 for (ConstraintMatchTotal constraintMatchTotal
                         : stepScope.getScoreDirector().getConstraintMatchTotals()) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/CustomShadowVariable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/variable/CustomShadowVariable.java
@@ -36,7 +36,7 @@ import static java.lang.annotation.RetentionPolicy.*;
 public @interface CustomShadowVariable {
 
     /**
-     * Use this when this shadow variable is updated by the {@link VariableListener} of another {@link @CustomShadowVariable}.
+     * Use this when this shadow variable is updated by the {@link VariableListener} of another {@link CustomShadowVariable}.
      * @return null if (and only if) any of the other fields is non null.
      */
     PlanningVariableReference variableListenerRef() default @PlanningVariableReference(variableName = "");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScore.java
@@ -177,11 +177,11 @@ public final class BendableBigDecimalScore extends AbstractScore<BendableBigDeci
         // TODO FIXME remove .intValue() so non-integer exponents produce correct results
         // None of the normal Java libraries support BigDecimal.pow(BigDecimal)
         for (int i = 0; i < newHardScores.length; i++) {
-            BigDecimal hardScore = hardScores[i]; 
+            BigDecimal hardScore = hardScores[i];
             newHardScores[i] = hardScore.pow(actualExponent.intValue()).setScale(hardScore.scale());
         }
         for (int i = 0; i < newSoftScores.length; i++) {
-            BigDecimal softScore = softScores[i]; 
+            BigDecimal softScore = softScores[i];
             newSoftScores[i] = softScore.pow(actualExponent.intValue()).setScale(softScore.scale());
         }
         return new BendableBigDecimalScore(newHardScores, newSoftScores);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/event/BestSolutionChangedEvent.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/event/BestSolutionChangedEvent.java
@@ -61,9 +61,9 @@ public class BestSolutionChangedEvent<SolutionG extends Solution> extends EventO
      * Note that:
      * <ul>
      *     <li>In real-time planning, not all {@link ProblemFactChange}s might be processed:
-     *     check {@link #isEveryProblemFactChangeProcessed()}</li>
-     *     <li>this {@link Solution} might be uninitialized: check {@link #isNewBestSolutionInitialized()}</li>
-     *     <li>this {@link Solution} might be infeasible: check {@link FeasibilityScore#isFeasible()}</li>
+     *     check {@link #isEveryProblemFactChangeProcessed()}.</li>
+     *     <li>this {@link Solution} might be uninitialized: check {@link #isNewBestSolutionInitialized()}.</li>
+     *     <li>this {@link Solution} might be infeasible: check {@link FeasibilityScore#isFeasible()}.</li>
      * </ul>
      * @return never null
      */

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/decorator/SelectionSorterOrder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/common/decorator/SelectionSorterOrder.java
@@ -23,11 +23,11 @@ import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSo
  */
 public enum SelectionSorterOrder {
     /**
-     * For example: 0, 1, 2, 3
+     * For example: 0, 1, 2, 3.
      */
     ASCENDING,
     /**
-     * For example: 3, 2, 1, 0
+     * For example: 3, 2, 1, 0.
      */
     DESCENDING;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySelectorConfig.java
@@ -545,8 +545,8 @@ public class EntitySelectorConfig extends SelectorConfig {
         }
         cacheType = ConfigUtils.inheritOverwritableProperty(cacheType, inheritedConfig.getCacheType());
         selectionOrder = ConfigUtils.inheritOverwritableProperty(selectionOrder, inheritedConfig.getSelectionOrder());
-        filterClassList = ConfigUtils.inheritOverwritableProperty
-                (filterClassList, inheritedConfig.getFilterClassList());
+        filterClassList = ConfigUtils.inheritOverwritableProperty(
+                filterClassList, inheritedConfig.getFilterClassList());
         sorterManner = ConfigUtils.inheritOverwritableProperty(
                 sorterManner, inheritedConfig.getSorterManner());
         sorterComparatorClass = ConfigUtils.inheritOverwritableProperty(

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/termination/TerminationConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/solver/termination/TerminationConfig.java
@@ -181,7 +181,7 @@ public class TerminationConfig implements Cloneable {
     public void setTerminationConfigList(List<TerminationConfig> terminationConfigList) {
         this.terminationConfigList = terminationConfigList;
     }
-    
+
     // ************************************************************************
     // Builder methods
     // ************************************************************************

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/ReflectionHelper.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/ReflectionHelper.java
@@ -114,7 +114,7 @@ public final class ReflectionHelper {
                 + (propertyName.isEmpty() ? "" : propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1));
         try {
             return containingClass.getMethod(getterName);
-        } catch (NoSuchMethodException e) {}
+        } catch (NoSuchMethodException e) { }
         String isserName = PROPERTY_ACCESSOR_PREFIX_IS
                 + (propertyName.isEmpty() ? "" : propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1));
         try {
@@ -122,7 +122,7 @@ public final class ReflectionHelper {
             if (method.getReturnType() == boolean.class) {
                 return method;
             }
-        } catch (NoSuchMethodException e) {}
+        } catch (NoSuchMethodException e) { }
         return null;
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/entity/descriptor/EntityDescriptor.java
@@ -317,7 +317,7 @@ public class EntityDescriptor {
     public Class<?> getEntityClass() {
         return entityClass;
     }
-    
+
     public boolean matchesEntity(Object entity) {
         return entityClass.isAssignableFrom(entity.getClass());
     }
@@ -357,7 +357,7 @@ public class EntityDescriptor {
     public boolean hasGenuineVariableDescriptor(String variableName) {
         return effectiveGenuineVariableDescriptorMap.containsKey(variableName);
     }
-    
+
     public GenuineVariableDescriptor getGenuineVariableDescriptor(String variableName) {
         return effectiveGenuineVariableDescriptorMap.get(variableName);
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/cloner/FieldAccessingSolutionCloner.java
@@ -192,7 +192,7 @@ public class FieldAccessingSolutionCloner<SolutionG extends Solution> implements
 
     protected class FieldAccessingSolutionClonerRun {
 
-        protected Map<Object,Object> originalToCloneMap;
+        protected Map<Object, Object> originalToCloneMap;
         protected Queue<Unprocessed> unprocessedQueue;
 
         protected SolutionG cloneSolution(SolutionG originalSolution) {
@@ -276,7 +276,7 @@ public class FieldAccessingSolutionCloner<SolutionG extends Solution> implements
             if (unprocessed.originalValue instanceof Collection) {
                 cloneValue = cloneCollection(unprocessed.field.getType(), (Collection<?>) unprocessed.originalValue);
             } else if (unprocessed.originalValue instanceof Map) {
-                cloneValue = cloneMap(unprocessed.field.getType(), (Map<?,?>) unprocessed.originalValue);
+                cloneValue = cloneMap(unprocessed.field.getType(), (Map<?, ?>) unprocessed.originalValue);
             } else {
                 cloneValue = clone(unprocessed.originalValue);
             }
@@ -307,7 +307,7 @@ public class FieldAccessingSolutionCloner<SolutionG extends Solution> implements
                 } else { // Default List
                     return new ArrayList<E>(originalCollection.size());
                 }
-            } if (originalCollection instanceof Set) {
+            } else if (originalCollection instanceof Set) {
                 if (originalCollection instanceof SortedSet) {
                     Comparator<E> setComparator = ((SortedSet) originalCollection).comparator();
                     return new TreeSet<E>(setComparator);
@@ -324,15 +324,15 @@ public class FieldAccessingSolutionCloner<SolutionG extends Solution> implements
             }
         }
 
-        protected <K,V> Map<K,V> cloneMap(Class<?> expectedType, Map<K,V> originalMap) {
-            Map<K,V> cloneMap = constructCloneMap(originalMap);
+        protected <K, V> Map<K, V> cloneMap(Class<?> expectedType, Map<K, V> originalMap) {
+            Map<K, V> cloneMap = constructCloneMap(originalMap);
             if (!expectedType.isInstance(cloneMap)) {
                 throw new IllegalStateException("The cloneMapClass (" + cloneMap.getClass()
                         + ") created for originalMapClass (" + originalMap.getClass()
                         + ") is not assignable to the field's type (" + expectedType + ")."
                         + " Consider replacing the default " + SolutionCloner.class.getSimpleName() + ".");
             }
-            for (Map.Entry<K,V> originalEntry : originalMap.entrySet()) {
+            for (Map.Entry<K, V> originalEntry : originalMap.entrySet()) {
                 K cloneKey = cloneCollectionsElementIfNeeded(originalEntry.getKey());
                 V cloneValue = cloneCollectionsElementIfNeeded(originalEntry.getValue());
                 cloneMap.put(cloneKey, cloneValue);
@@ -340,18 +340,18 @@ public class FieldAccessingSolutionCloner<SolutionG extends Solution> implements
             return cloneMap;
         }
 
-        protected <K,V> Map<K,V> constructCloneMap(Map<K,V> originalMap) {
+        protected <K, V> Map<K, V> constructCloneMap(Map<K, V> originalMap) {
             // Normally a Map will never be selected for cloning, but extending implementations might anyway
             if (originalMap instanceof SortedMap) {
                 Comparator setComparator = ((SortedMap) originalMap).comparator();
-                return new TreeMap<K,V>(setComparator);
+                return new TreeMap<K, V>(setComparator);
             } else if (originalMap instanceof LinkedHashMap) {
-                return new LinkedHashMap<K,V>(originalMap.size());
+                return new LinkedHashMap<K, V>(originalMap.size());
             } else if (originalMap instanceof HashMap) {
-                return new HashMap<K,V>(originalMap.size());
+                return new HashMap<K, V>(originalMap.size());
             } else { // Default Map
                 // Default to a LinkedHashMap to respect order
-                return new LinkedHashMap<K,V>(originalMap.size());
+                return new LinkedHashMap<K, V>(originalMap.size());
             }
         }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -108,7 +108,7 @@ public class SolutionDescriptor {
 
     private final Class<? extends Solution> solutionClass;
     private SolutionCloner solutionCloner;
-    
+
     private final Map<String, MemberAccessor> entityPropertyAccessorMap;
     private final Map<String, MemberAccessor> entityCollectionPropertyAccessorMap;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/mutation/MutationCounter.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/mutation/MutationCounter.java
@@ -43,7 +43,7 @@ public class MutationCounter {
         for (EntityDescriptor entityDescriptor : solutionDescriptor.getGenuineEntityDescriptors()) {
             List<Object> aEntities = entityDescriptor.extractEntities(a);
             List<Object> bEntities = entityDescriptor.extractEntities(b);
-            for (Iterator aIt = aEntities.iterator(), bIt = bEntities.iterator() ; aIt.hasNext() && bIt.hasNext(); ) {
+            for (Iterator aIt = aEntities.iterator(), bIt = bEntities.iterator(); aIt.hasNext() && bIt.hasNext(); ) {
                 Object aEntity =  aIt.next();
                 Object bEntity =  bIt.next();
                 for (GenuineVariableDescriptor variableDescriptor : entityDescriptor.getGenuineVariableDescriptors()) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/ExhaustiveSearchLayer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/ExhaustiveSearchLayer.java
@@ -59,7 +59,7 @@ public class ExhaustiveSearchLayer {
 
     @Override
     public String toString() {
-        return depth + (isLastLayer() ? " last layer": " (" + entity + ")");
+        return depth + (isLastLayer() ? " last layer" : " (" + entity + ")");
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/move/AbstractMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/move/AbstractMove.java
@@ -17,7 +17,7 @@
 package org.optaplanner.core.impl.heuristic.move;
 
 /**
- * Abstract superclass for {@link Move}
+ * Abstract superclass for {@link Move}.
  * @see Move
  */
 public abstract class AbstractMove implements Move {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/iterator/ListIterable.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/iterator/ListIterable.java
@@ -20,21 +20,19 @@ import java.util.List;
 import java.util.ListIterator;
 
 /**
- * An extension on the {@link Iterable} interface that supports {@link #listIterator()} and  {@link #listIterator(int)}.
+ * An extension on the {@link Iterable} interface that supports {@link #listIterator()} and {@link #listIterator(int)}.
  * @param <T> the element type
  */
 public interface ListIterable<T> extends Iterable<T> {
 
     /**
-     * See {@link List#listIterator()}
-     *
+     * @see List#listIterator()
      * @return never null, see {@link List#listIterator()}.
      */
     ListIterator<T> listIterator();
 
     /**
-     * See {@link List#listIterator()}
-     *
+     * @see List#listIterator()
      * @param index lower than the size of this {@link ListIterable}, see {@link List#listIterator(int)}.
      * @return never null, see {@link List#listIterator(int)}.
      */

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/LinearDistributionNearbyRandom.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/LinearDistributionNearbyRandom.java
@@ -19,9 +19,11 @@ package org.optaplanner.core.impl.heuristic.selector.common.nearby;
 import java.util.Random;
 
 /**
- * P(x) = 2/m - 2x/m²
- * Cumulative probability F(x) = x(2m - x)/m²
- * Inverse cumulative probability F(p) = m(1 - (1 - p)^(1/2))
+ * {@code P(x) = 2/m - 2x/m²}.
+ * <p>
+ * Cumulative probability: {@code F(x) = x(2m - x)/m²}.
+ * <p>
+ * Inverse cumulative probability: {@code F(p) = m(1 - (1 - p)^(1/2))}.
  */
 public class LinearDistributionNearbyRandom implements NearbyRandom {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/ParabolicDistributionNearbyRandom.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/ParabolicDistributionNearbyRandom.java
@@ -19,9 +19,11 @@ package org.optaplanner.core.impl.heuristic.selector.common.nearby;
 import java.util.Random;
 
 /**
- * P(x) = 3(m - x)²/m³
- * Cumulative probability F(x) = 1 - (1 - x/m)³
- * Inverse cumulative probability F(p) = m(1 - (1 - p)^(1/3))
+ * {@code P(x) = 3(m - x)²/m³}.
+ * <p>
+ * Cumulative probability: {@code F(x) = 1 - (1 - x/m)³}.
+ * <p>
+ * Inverse cumulative probability: {@code F(p) = m(1 - (1 - p)^(1/3))}.
  */
 public class ParabolicDistributionNearbyRandom implements NearbyRandom {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/nearby/NearEntityNearbyEntitySelector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/entity/nearby/NearEntityNearbyEntitySelector.java
@@ -38,7 +38,7 @@ public class NearEntityNearbyEntitySelector extends AbstractEntitySelector {
     protected final NearbyDistanceMeter nearbyDistanceMeter;
     protected final NearbyRandom nearbyRandom;
     protected final boolean randomSelection;
-    protected final boolean discardNearbyIndexZero = true;// TODO deactivate me when appropriate
+    protected final boolean discardNearbyIndexZero = true; // TODO deactivate me when appropriate
 
     protected Map<Object, Object[]> originToDestinationsMap = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelector.java
@@ -192,7 +192,7 @@ public class CartesianProductMoveSelector extends CompositeMoveSelector {
                         }
                     }
                 }
-                empty = ignoreEmptyChildIterators ? emptyCount == moveIteratorList.size(): emptyCount > 0;
+                empty = ignoreEmptyChildIterators ? emptyCount == moveIteratorList.size() : emptyCount > 0;
             }
             return !empty;
         }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarChangeMove.java
@@ -32,7 +32,7 @@ import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 
 /**
- * Non-cacheable
+ * Non-cacheable.
  */
 public class PillarChangeMove extends AbstractMove {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarSwapMove.java
@@ -32,7 +32,7 @@ import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 
 /**
- * Non-cacheable
+ * Non-cacheable.
  */
 public class PillarSwapMove extends AbstractMove {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainChangeMoveSelector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainChangeMoveSelector.java
@@ -48,7 +48,7 @@ public class SubChainChangeMoveSelector extends GenericMoveSelector {
                     + ") has a subChainSelector (" + subChainSelector
                     + ") with variableDescriptor (" + subChainSelector.getVariableDescriptor()
                     + ") which is not the same as the valueSelector (" + valueSelector
-                    +")'s variableDescriptor(" + valueSelector.getVariableDescriptor() + ").");
+                    + ")'s variableDescriptor(" + valueSelector.getVariableDescriptor() + ").");
         }
         if (!randomSelection) {
             if (subChainSelector.isNeverEnding()) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingSwapMove.java
@@ -29,7 +29,7 @@ import org.optaplanner.core.impl.heuristic.selector.value.chained.SubChain;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 
 /**
- * Non-cacheable
+ * Non-cacheable.
  */
 public class SubChainReversingSwapMove extends AbstractMove {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainSwapMove.java
@@ -29,7 +29,7 @@ import org.optaplanner.core.impl.heuristic.selector.value.chained.SubChain;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 
 /**
- * Non-cacheable
+ * Non-cacheable.
  */
 public class SubChainSwapMove extends AbstractMove {
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/TailChainSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/TailChainSwapMove.java
@@ -70,7 +70,7 @@ public class TailChainSwapMove extends AbstractMove {
         Object leftValue = variableDescriptor.getValue(leftEntity);
         Object rightEntity = inverseVariableSupply.getInverseSingleton(rightValue);
         if (ObjectUtils.equals(leftValue, rightValue)
-                || ObjectUtils.equals(leftEntity, rightValue) || ObjectUtils.equals(rightEntity, leftValue) ) {
+                || ObjectUtils.equals(leftEntity, rightValue) || ObjectUtils.equals(rightEntity, leftValue)) {
             return false;
         }
         if (rightEntity == null) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/nearby/NearEntityNearbyValueSelector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/value/nearby/NearEntityNearbyValueSelector.java
@@ -38,7 +38,7 @@ public class NearEntityNearbyValueSelector extends AbstractValueSelector {
     protected final NearbyDistanceMeter nearbyDistanceMeter;
     protected final NearbyRandom nearbyRandom;
     protected final boolean randomSelection;
-    protected final boolean discardNearbyIndexZero = true;// TODO deactivate me when appropriate
+    protected final boolean discardNearbyIndexZero = true; // TODO deactivate me when appropriate
 
     protected Map<Object, Object[]> originToDestinationsMap = null;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/SolutionTabuAcceptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/SolutionTabuAcceptor.java
@@ -44,7 +44,7 @@ public class SolutionTabuAcceptor extends AbstractTabuAcceptor {
         // TODO this should be better done in stepEnded
         return Collections.singletonList(stepScope.createOrGetClonedSolution());
     }
-    
+
     @Override
     public void phaseStarted(LocalSearchPhaseScope phaseScope) {
         super.phaseStarted(phaseScope);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/custom/CustomPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/custom/CustomPhase.java
@@ -20,7 +20,7 @@ import org.optaplanner.core.impl.phase.AbstractPhase;
 import org.optaplanner.core.impl.phase.Phase;
 
 /**
- * A {@link CustomPhase} is a {@link Phase} which uses the brute force algorithm
+ * A {@link CustomPhase} is a {@link Phase} which uses the brute force algorithm.
  * @see Phase
  * @see AbstractPhase
  * @see DefaultCustomPhase

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/definition/ScoreDefinition.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/definition/ScoreDefinition.java
@@ -36,7 +36,7 @@ public interface ScoreDefinition<S extends Score> {
     int getLevelsSize();
 
     /**
-     * Returns the {@link Class} of the actual {@link Score} implementation
+     * Returns the {@link Class} of the actual {@link Score} implementation.
      * @return never null
      */
     Class<S> getScoreClass();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/easy/EasyScoreCalculator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/easy/EasyScoreCalculator.java
@@ -36,5 +36,5 @@ public interface EasyScoreCalculator<Sol extends Solution> {
      * @return never null
      */
     Score calculateScore(Sol solution);
-    
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/trend/InitializingScoreTrend.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/trend/InitializingScoreTrend.java
@@ -36,7 +36,7 @@ public class InitializingScoreTrend implements Serializable {
             throw new IllegalArgumentException("The initializingScoreTrendString (" + initializingScoreTrendString
                     + ") doesn't follow the correct pattern (" + buildTrendPattern(levelsSize) + "):"
                     + " the trendTokens length (" + trendTokens.length
-                    + ") differs from the levelsSize (" + levelsSize + ")." );
+                    + ") differs from the levelsSize (" + levelsSize + ").");
         }
         InitializingScoreTrendLevel[] trendLevels = new InitializingScoreTrendLevel[levelsSize];
         for (int i = 0; i < levelsSize; i++) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/BasicPlumbingTermination.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/BasicPlumbingTermination.java
@@ -26,7 +26,7 @@ import org.optaplanner.core.impl.solver.termination.AbstractTermination;
 
 /**
  * Concurrency notes:
- * Condition predicate on ({@link #problemFactChangeQueue} is not empty or {@link #terminatedEarly} is true)
+ * Condition predicate on ({@link #problemFactChangeQueue} is not empty or {@link #terminatedEarly} is true).
  */
 public class BasicPlumbingTermination extends AbstractTermination {
 
@@ -44,13 +44,13 @@ public class BasicPlumbingTermination extends AbstractTermination {
     // ************************************************************************
     // Plumbing worker methods
     // ************************************************************************
-    
+
     public synchronized void resetTerminateEarly() {
         terminatedEarly = false;
     }
 
     /**
-     * Concurrency note: unblocks {@link #waitForRestartSolverDecision()}
+     * Concurrency note: unblocks {@link #waitForRestartSolverDecision()}.
      * @return true if successful
      */
     public synchronized boolean terminateEarly() {
@@ -89,7 +89,7 @@ public class BasicPlumbingTermination extends AbstractTermination {
     }
 
     /**
-     * Concurrency note: unblocks {@link #waitForRestartSolverDecision()}
+     * Concurrency note: unblocks {@link #waitForRestartSolverDecision()}.
      * @param problemFactChange never null
      * @return as specified by {@link Collection#add}
      */

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/AndCompositeTermination.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/termination/AndCompositeTermination.java
@@ -23,7 +23,7 @@ import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
 
 public class AndCompositeTermination extends AbstractCompositeTermination {
 
-    public AndCompositeTermination(List<Termination>terminationList) {
+    public AndCompositeTermination(List<Termination> terminationList) {
         super(terminationList);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreHolderTest.java
@@ -52,7 +52,7 @@ public class BendableBigDecimalScoreHolderTest extends AbstractScoreHolderTest {
 
         scoreHolder.addSoftConstraintMatch(createRuleContext("scoreRule4"), 1, BigDecimal.valueOf(-4)); // Rule match added
 
-        assertEquals(BendableBigDecimalScore.valueOf(new BigDecimal[]{BigDecimal.valueOf(-1000)}, 
+        assertEquals(BendableBigDecimalScore.valueOf(new BigDecimal[]{BigDecimal.valueOf(-1000)},
                 new BigDecimal[]{BigDecimal.valueOf(-3), BigDecimal.valueOf(-4)}), scoreHolder.extractScore());
         if (constraintMatchEnabled) {
             assertEquals(4, scoreHolder.getConstraintMatchTotals().size());

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
@@ -60,12 +60,12 @@ public class BendableBigDecimalScoreTest extends AbstractScoreTest {
     private static final BigDecimal MINUS_5000 = BigDecimal.valueOf(-5000);
     private static final BigDecimal MINUS_8000 = BigDecimal.valueOf(-8000);
     private static final BigDecimal MIN_INTEGER = BigDecimal.valueOf(Integer.MIN_VALUE);
-    
+
     private BendableBigDecimalScoreDefinition scoreDefinitionHSS = new BendableBigDecimalScoreDefinition(1, 2);
 
     @Test
     public void parseScore() {
-        assertEquals(scoreDefinitionHSS.createScore(BigDecimal.valueOf(-147), BigDecimal.valueOf(-258), 
+        assertEquals(scoreDefinitionHSS.createScore(BigDecimal.valueOf(-147), BigDecimal.valueOf(-258),
                 BigDecimal.valueOf(-369)), scoreDefinitionHSS.parseScore("-147/-258/-369"));
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/primlong/LongValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/primlong/LongValueRangeTest.java
@@ -57,7 +57,7 @@ public class LongValueRangeTest {
         assertEquals(true, new LongValueRange(0L, 10L).contains(3L));
         assertEquals(false, new LongValueRange(0L, 10L).contains(10L));
         assertEquals(false, new LongValueRange(0L, 10L).contains(null));
-        assertEquals(true, new LongValueRange(100L, 120l).contains(100L));
+        assertEquals(true, new LongValueRange(100L, 120L).contains(100L));
         assertEquals(false, new LongValueRange(100L, 120L).contains(99L));
         assertEquals(true, new LongValueRange(-5L, 25L).contains(-4L));
         assertEquals(false, new LongValueRange(-5L, 25L).contains(-20L));

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/decorator/ComparatorSelectionSorterTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/decorator/ComparatorSelectionSorterTest.java
@@ -36,7 +36,7 @@ public class ComparatorSelectionSorterTest {
         ComparatorSelectionSorter selectionSorter = new ComparatorSelectionSorter(new TestComparator(), SelectionSorterOrder.ASCENDING);
         selectionSorter.sort(null, arrayToSort);
         assertTrue(ascendingSort(arrayToSort));
-        
+
         arrayToSort = new ArrayList<Object>();
         Collections.addAll(arrayToSort, baseArray);
         selectionSorter = new ComparatorSelectionSorter(new TestComparator(), SelectionSorterOrder.DESCENDING);
@@ -49,7 +49,9 @@ public class ComparatorSelectionSorterTest {
         for (Object aList : list) {
             if (tmp <= (Integer) aList) {
                 tmp = (Integer) aList;
-            } else return false;
+            } else {
+                return false;
+            }
         }
         return true;
     }
@@ -59,7 +61,9 @@ public class ComparatorSelectionSorterTest {
         for (Object aList : list) {
             if (tmp >= (Integer) aList) {
                 tmp = (Integer) aList;
-            } else return false;
+            } else {
+                return false;
+            }
         }
         return true;
     }
@@ -70,7 +74,7 @@ public class ComparatorSelectionSorterTest {
         public int compare(Object o, Object o2) {
             Integer first = (Integer) o;
             Integer second = (Integer) o2;
-            if(first.intValue() == second.intValue()) {
+            if (first.intValue() == second.intValue()) {
                 return 0;
             }
             return first > second ? 1 : -1;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/BlockDistributionNearbyRandomTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/common/nearby/BlockDistributionNearbyRandomTest.java
@@ -41,7 +41,7 @@ public class BlockDistributionNearbyRandomTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void sizeRatioTooHigh(){
+    public void sizeRatioTooHigh() {
         NearbyRandom nearbyRandom = new BlockDistributionNearbyRandom(10, 300, 1.2, 0.0);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/FromSolutionEntitySelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/entity/FromSolutionEntitySelectorTest.java
@@ -377,7 +377,7 @@ public class FromSolutionEntitySelectorTest {
     @Test(expected = IllegalStateException.class)
     public void listIteratorWithRandomSelection() {
         EntityDescriptor entityDescriptor = mock(EntityDescriptor.class);
-        when(entityDescriptor.getEntityClass()).thenReturn((Class)TestdataEntity.class);
+        when(entityDescriptor.getEntityClass()).thenReturn((Class) TestdataEntity.class);
         FromSolutionEntitySelector entitySelector = new FromSolutionEntitySelector(entityDescriptor, SelectionCacheType.JUST_IN_TIME, true);
         entitySelector.listIterator();
     }
@@ -385,7 +385,7 @@ public class FromSolutionEntitySelectorTest {
     @Test(expected = IllegalStateException.class)
     public void indexedListIteratorWithRandomSelection() {
         EntityDescriptor entityDescriptor = mock(EntityDescriptor.class);
-        when(entityDescriptor.getEntityClass()).thenReturn((Class)TestdataEntity.class);
+        when(entityDescriptor.getEntityClass()).thenReturn((Class) TestdataEntity.class);
         FromSolutionEntitySelector entitySelector = new FromSolutionEntitySelector(entityDescriptor, SelectionCacheType.JUST_IN_TIME, true);
         entitySelector.listIterator(0);
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/move/composite/CartesianProductMoveSelectorTest.java
@@ -113,7 +113,7 @@ public class CartesianProductMoveSelectorTest {
     public void emptyOriginSelection(boolean ignoreEmptyChildIterators, boolean emptyFirst, boolean emptySecond) {
         assertTrue(emptyFirst || emptySecond);
         MoveSelector nonEmptyChildMoveSelector = SelectorTestUtils.mockMoveSelector(DummyMove.class,
-                new DummyMove("a1"), new DummyMove("a2"), new DummyMove("a3"));// One side is not empty
+                new DummyMove("a1"), new DummyMove("a2"), new DummyMove("a3")); // One side is not empty
         ArrayList<MoveSelector> childMoveSelectorList = new ArrayList<MoveSelector>();
         childMoveSelectorList.add(emptyFirst
                 ? SelectorTestUtils.mockMoveSelector(DummyMove.class) : nonEmptyChildMoveSelector);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/lateacceptance/LateAcceptanceAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/lateacceptance/LateAcceptanceAcceptorTest.java
@@ -131,7 +131,7 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
         // bestScore unchanged
         acceptor.stepEnded(stepScope5);
         phaseScope.setLastCompletedStepScope(stepScope5);
-        
+
         acceptor.phaseEnded(phaseScope);
     }
 
@@ -226,7 +226,7 @@ public class LateAcceptanceAcceptorTest extends AbstractAcceptorTest {
 
         // lateScore = -200, lastCompletedStepScore = -300
         LocalSearchStepScope stepScope5 = new LocalSearchStepScope(phaseScope);
-        LocalSearchMoveScope moveScope5= buildMoveScope(stepScope1, -300);
+        LocalSearchMoveScope moveScope5 = buildMoveScope(stepScope1, -300);
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope5, -301)));
         assertEquals(false, acceptor.isAccepted(buildMoveScope(stepScope5, -400)));
         assertEquals(true, acceptor.isAccepted(moveScope5));

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/latesimulatedannealing/LateSimulatedAnnealingAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/latesimulatedannealing/LateSimulatedAnnealingAcceptorTest.java
@@ -120,7 +120,7 @@ public class LateSimulatedAnnealingAcceptorTest extends AbstractAcceptorTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void negativeLateSimulatedAnnealingSize() {
-        LateSimulatedAnnealingAcceptor acceptor= new LateSimulatedAnnealingAcceptor();
+        LateSimulatedAnnealingAcceptor acceptor = new LateSimulatedAnnealingAcceptor();
         acceptor.setLateSimulatedAnnealingSize(-1);
         acceptor.phaseStarted(null);
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/EntityTabuAcceptorTest.java
@@ -62,7 +62,7 @@ public class EntityTabuAcceptorTest {
         stepScope0.setStep(moveScope1.getMove());
         acceptor.stepEnded(stepScope0);
         phaseScope.setLastCompletedStepScope(stepScope0);
-        
+
         LocalSearchStepScope stepScope1 = new LocalSearchStepScope(phaseScope);
         LocalSearchMoveScope moveScope2 = buildMoveScope(stepScope1, e2);
         assertEquals(true, acceptor.isAccepted(buildMoveScope(stepScope1, e0)));
@@ -110,7 +110,7 @@ public class EntityTabuAcceptorTest {
         stepScope4.setStep(moveScope1Again.getMove());
         acceptor.stepEnded(stepScope4);
         phaseScope.setLastCompletedStepScope(stepScope4);
-        
+
         acceptor.phaseEnded(phaseScope);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/AbstractScoreDirectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/AbstractScoreDirectorTest.java
@@ -80,7 +80,7 @@ public class AbstractScoreDirectorTest {
         assertEquals(a2, scoreDirector.getTrailingEntity(variableDescriptor, a1));
         assertEquals(a3, scoreDirector.getTrailingEntity(variableDescriptor, a2));
         assertEquals(b1, scoreDirector.getTrailingEntity(variableDescriptor, b0));
-        
+
         scoreDirector.beforeVariableChanged(a3, "chainedObject");
         a3.setChainedObject(b1);
         scoreDirector.afterVariableChanged(a3, "chainedObject");

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/recaller/BestSolutionRecallerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/recaller/BestSolutionRecallerTest.java
@@ -117,7 +117,7 @@ public class BestSolutionRecallerTest {
         when(phaseScope.getSolverScope()).thenReturn(solverScope);
         ConstructionHeuristicStepScope stepScope = mock(ConstructionHeuristicStepScope.class);
         when(stepScope.getPhaseScope()).thenReturn(phaseScope);
-        
+
         Solution solution = mock(Solution.class);
         Score score = SimpleScore.parseScore("-1");
         when(solution.getScore()).thenReturn(score);
@@ -201,7 +201,7 @@ public class BestSolutionRecallerTest {
 
         recaller.processWorkingSolutionDuringMove(0, score, stepScope);
         assertEquals(helpSolution, solverScope.getBestSolution());
-        assertEquals(-2, ((SimpleScore)solverScope.getBestScore()).getScore());
+        assertEquals(-2, ((SimpleScore) solverScope.getBestScore()).getScore());
         assertEquals(0, solverScope.getBestUninitializedVariableCount());
     }
 
@@ -231,7 +231,7 @@ public class BestSolutionRecallerTest {
         solverScope.setBestUninitializedVariableCount(0);
         recaller.processWorkingSolutionDuringMove(0, score2, stepScope);
         assertEquals(helpSolution, solverScope.getBestSolution());
-        assertEquals(0, ((SimpleScore)solverScope.getBestScore()).getScore());
+        assertEquals(0, ((SimpleScore) solverScope.getBestScore()).getScore());
         assertEquals(0, solverScope.getBestUninitializedVariableCount());
     }
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/app/OptaPlannerExamplesApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/app/OptaPlannerExamplesApp.java
@@ -65,8 +65,7 @@ import org.optaplanner.examples.vehiclerouting.app.VehicleRoutingApp;
 public class OptaPlannerExamplesApp extends JFrame {
 
     /**
-     * Supported system properties:
-     * {@link AbstractSolutionDao#DATA_DIR_SYSTEM_PROPERTY}
+     * Supported system properties: {@link AbstractSolutionDao#DATA_DIR_SYSTEM_PROPERTY}.
      * @param args never null
      */
     public static void main(String[] args) {
@@ -257,7 +256,7 @@ public class OptaPlannerExamplesApp extends JFrame {
     private class WebExamplesDialog extends JDialog {
 
         private WebExamplesDialog() {
-            super (OptaPlannerExamplesApp.this, "Web examples", true);
+            super(OptaPlannerExamplesApp.this, "Web examples", true);
             JPanel contentPanel = new JPanel(new BorderLayout(5, 5));
             contentPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
             contentPanel.add(createMiddlePanel(), BorderLayout.CENTER);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/domain/TaskAssignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/domain/TaskAssignment.java
@@ -66,7 +66,7 @@ public class TaskAssignment extends AbstractPersistable {
     // ************************************************************************
 
     /**
-     * Exclusive
+     * Exclusive.
      * @return null if {@link #getStartPeriod()} is null
      */
     public Integer getEndPeriod() {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/solver/score/CloudBalancingIncrementalScoreCalculator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/solver/score/CloudBalancingIncrementalScoreCalculator.java
@@ -31,7 +31,7 @@ public class CloudBalancingIncrementalScoreCalculator extends AbstractIncrementa
     private Map<CloudComputer, Integer> memoryUsageMap;
     private Map<CloudComputer, Integer> networkBandwidthUsageMap;
     private Map<CloudComputer, Integer> processCountMap;
-    
+
     private int hardScore;
     private int softScore;
 
@@ -90,7 +90,7 @@ public class CloudBalancingIncrementalScoreCalculator extends AbstractIncrementa
             int newCpuPowerAvailable = cpuPower - newCpuPowerUsage;
             hardScore += Math.min(newCpuPowerAvailable, 0) - Math.min(oldCpuPowerAvailable, 0);
             cpuPowerUsageMap.put(computer, newCpuPowerUsage);
-            
+
             int memory = computer.getMemory();
             int oldMemoryUsage = memoryUsageMap.get(computer);
             int oldMemoryAvailable = memory - oldMemoryUsage;
@@ -98,7 +98,7 @@ public class CloudBalancingIncrementalScoreCalculator extends AbstractIncrementa
             int newMemoryAvailable = memory - newMemoryUsage;
             hardScore += Math.min(newMemoryAvailable, 0) - Math.min(oldMemoryAvailable, 0);
             memoryUsageMap.put(computer, newMemoryUsage);
-            
+
             int networkBandwidth = computer.getNetworkBandwidth();
             int oldNetworkBandwidthUsage = networkBandwidthUsageMap.get(computer);
             int oldNetworkBandwidthAvailable = networkBandwidth - oldNetworkBandwidthUsage;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/swingui/CloudComputerPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/swingui/CloudComputerPanel.java
@@ -360,5 +360,5 @@ public class CloudComputerPanel extends JPanel {
         }
 
     }
-    
+
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/TangoColorFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/TangoColorFactory.java
@@ -79,7 +79,7 @@ public class TangoColorFactory {
 
     public static final Stroke LIGHT_DASHED_STROKE = new BasicStroke(
             1.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND, 1.0f, new float[] {3.0f, 7.0f}, 0.0f);
-    
+
     private Map<Object, Color> colorMap;
     private int nextColorCount;
 
@@ -87,7 +87,7 @@ public class TangoColorFactory {
         colorMap = new HashMap<Object, Color>();
         nextColorCount = 0;
     }
-    
+
     public Color pickColor(Object o) {
         Color color = colorMap.get(o);
         if (color == null) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/timetable/TimeTableLayout.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/timetable/TimeTableLayout.java
@@ -105,11 +105,11 @@ public class TimeTableLayout implements LayoutManager2, Serializable {
         TimeTableLayoutConstraints c = (TimeTableLayoutConstraints) o;
         if (c.getXEnd() > columns.size()) {
             throw new IllegalArgumentException("The xEnd (" + c.getXEnd()
-                    + ") is > columnsSize (" +  columns.size() +").");
+                    + ") is > columnsSize (" +  columns.size() + ").");
         }
         if (c.getYEnd() > rows.size()) {
             throw new IllegalArgumentException("The yEnd (" + c.getYEnd()
-                    + ") is > rowsSize (" +  rows.size() +").");
+                    + ") is > rowsSize (" +  rows.size() + ").");
         }
         stale = true;
         ComponentSpan span = new ComponentSpan(component);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/InstitutionParametrization.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/InstitutionParametrization.java
@@ -20,7 +20,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
 /**
- * Institutional weightings
+ * Institutional weightings.
  */
 @XStreamAlias("InstitutionParametrization")
 public class InstitutionParametrization extends AbstractPersistable {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/domain/InvestmentParametrization.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/domain/InvestmentParametrization.java
@@ -20,7 +20,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
 /**
- * Institutional weightings
+ * Institutional weightings.
  */
 @XStreamAlias("InvestmentParametrization")
 public class InvestmentParametrization extends AbstractPersistable {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/domain/InvestmentSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/domain/InvestmentSolution.java
@@ -119,7 +119,7 @@ public class InvestmentSolution extends AbstractPersistable implements Solution<
     }
 
     /**
-     * Not incremental
+     * Not incremental.
      */
     public long calculateExpectedReturnMicros() {
         long expectedReturnMicros = 0L;
@@ -130,7 +130,7 @@ public class InvestmentSolution extends AbstractPersistable implements Solution<
     }
 
     /**
-     * Not incremental
+     * Not incremental.
      */
     public long calculateStandardDeviationMicros() {
         long squaredFemtos = calculateStandardDeviationSquaredFemtos();
@@ -138,7 +138,7 @@ public class InvestmentSolution extends AbstractPersistable implements Solution<
     }
 
     /**
-     * Not incremental
+     * Not incremental.
      */
     public long calculateStandardDeviationSquaredFemtos() {
         long totalFemtos = 0L;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/solver/move/factory/InvestmentQuantityTransferMoveIteratorFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/solver/move/factory/InvestmentQuantityTransferMoveIteratorFactory.java
@@ -99,7 +99,7 @@ public class InvestmentQuantityTransferMoveIteratorFactory implements MoveIterat
             AssetClassAllocation toAllocation = allocationList.get(workingRandom.nextInt(allocationList.size() - 1));
             if (toAllocation == fromAllocation) {
                 toAllocation = allocationList.get(allocationList.size() - 1);
-            };
+            }
             return new InvestmentQuantityTransferMove(fromAllocation, toAllocation, transferMillis);
         }
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MrProcessAssignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MrProcessAssignment.java
@@ -84,7 +84,7 @@ public class MrProcessAssignment extends AbstractPersistable {
     public MrLocation getLocation() {
         return machine == null ? null : machine.getLocation();
     }
-    
+
     public long getUsage(MrResource resource) {
         return process.getUsage(resource);
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/swingui/MrMachinePanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/swingui/MrMachinePanel.java
@@ -174,7 +174,7 @@ public class MrMachinePanel extends JPanel {
                 usedTotal += processAssignment.getProcess().getProcessRequirement(resource).getUsage();
             }
             resourceField.setText(usedTotal + " / " + maximumCapacity);
-            resourceField.setForeground(usedTotal > maximumCapacity? TangoColorFactory.SCARLET_3 :
+            resourceField.setForeground(usedTotal > maximumCapacity ? TangoColorFactory.SCARLET_3 :
                     (usedTotal > safetyCapacity ? TangoColorFactory.ORANGE_3 : Color.BLACK));
             resourceField.setEnabled(used);
         }
@@ -219,5 +219,5 @@ public class MrMachinePanel extends JPanel {
         }
 
     }
-    
+
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/Shift.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/Shift.java
@@ -61,7 +61,7 @@ public class Shift extends AbstractPersistable {
     }
 
     public String getLabel() {
-        return shiftType.getLabel() + " of " + shiftDate.getLabel() ;
+        return shiftType.getLabel() + " of " + shiftDate.getLabel();
     }
 
     @Override

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentPillarPartSwapMoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentPillarPartSwapMoveFactory.java
@@ -139,7 +139,7 @@ public class ShiftAssignmentPillarPartSwapMoveFactory implements MoveListFactory
     }
 
     /**
-     * TODO DRY with {@link EmployeeWorkSequence}
+     * TODO DRY with {@link EmployeeWorkSequence}.
      */
     private static class AssignmentSequence {
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentSequenceSwitchLength2MoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentSequenceSwitchLength2MoveFactory.java
@@ -118,7 +118,7 @@ public class ShiftAssignmentSequenceSwitchLength2MoveFactory implements MoveList
     }
 
     /**
-     * TODO DRY with {@link EmployeeWorkSequence}
+     * TODO DRY with {@link EmployeeWorkSequence}.
      */
     private static class AssignmentSequence {
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentSequenceSwitchLength3MoveFactory.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/solver/move/factory/ShiftAssignmentSequenceSwitchLength3MoveFactory.java
@@ -118,7 +118,7 @@ public class ShiftAssignmentSequenceSwitchLength3MoveFactory implements MoveList
     }
 
     /**
-     * TODO DRY with {@link EmployeeWorkSequence}
+     * TODO DRY with {@link EmployeeWorkSequence}.
      */
     private static class AssignmentSequence {
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/swingui/EmployeePanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/swingui/EmployeePanel.java
@@ -58,11 +58,11 @@ public class EmployeePanel extends JPanel {
     private JLabel employeeLabel;
     private JButton deleteButton;
     private JPanel shiftDateListPanel = null;
-    private Map<ShiftDate,JPanel> shiftDatePanelMap;
+    private Map<ShiftDate, JPanel> shiftDatePanelMap;
     private Map<Shift, JPanel> shiftPanelMap;
     private JLabel numberOfShiftAssignmentsLabel;
 
-    private Map<ShiftAssignment, JButton> shiftAssignmentButtonMap = new HashMap<ShiftAssignment, JButton> ();
+    private Map<ShiftAssignment, JButton> shiftAssignmentButtonMap = new HashMap<ShiftAssignment, JButton>();
 
     public EmployeePanel(NurseRosteringPanel nurseRosteringPanel, List<ShiftDate> shiftDateList, List<Shift> shiftList,
             Employee employee) {
@@ -258,5 +258,5 @@ public class EmployeePanel extends JPanel {
         }
 
     }
-    
+
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/swingui/NurseRosteringPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/swingui/NurseRosteringPanel.java
@@ -196,7 +196,7 @@ public class NurseRosteringPanel extends SolutionPanel {
                 if (windowStartIndex < 0) {
                     throw new IllegalStateException("The planningWindowStart ("
                             + planningWindowStart + ") must be in the shiftDateList ("
-                            + shiftDateList +").");
+                            + shiftDateList + ").");
                 }
                 ShiftDate oldLastShiftDate = shiftDateList.get(shiftDateList.size() - 1);
                 ShiftDate newShiftDate = new ShiftDate();

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/Equipment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/Equipment.java
@@ -20,7 +20,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
 /**
- * AKA RoomProperty
+ * AKA RoomProperty.
  */
 @XStreamAlias("Equipment")
 public class Equipment extends AbstractPersistable {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/persistence/PatientAdmissionScheduleImporter.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/persistence/PatientAdmissionScheduleImporter.java
@@ -487,7 +487,7 @@ public class PatientAdmissionScheduleImporter extends AbstractTxtSolutionImporte
                     if (hasEquipment == 1) {
                         boolean alreadyRequired = (Integer.parseInt(requiredPatientEquipmentTokens[j]) == 1);
                         // Official spec: if equipment is required
-                        // then a duplicate preffered constraint should be ignored 
+                        // then a duplicate preffered constraint should be ignored
                         if (!alreadyRequired) {
                             PreferredPatientEquipment preferredPatientEquipment = new PreferredPatientEquipment();
                             preferredPatientEquipment.setId(preferredPatientEquipmentId);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/persistence/ProjectJobSchedulingImporter.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/persistence/ProjectJobSchedulingImporter.java
@@ -246,7 +246,7 @@ public class ProjectJobSchedulingImporter extends AbstractTxtSolutionImporter {
                 }
                 if (Integer.parseInt(tokens[1]) != jobListSize - 2) {
                     throw new IllegalArgumentException("The project information tokens (" + Arrays.toString(tokens)
-                            + ") index 1 should be " + (jobListSize - 2) +".");
+                            + ") index 1 should be " + (jobListSize - 2) + ".");
                 }
                 // Ignore releaseDate, dueDate, tardinessCost and mpmTime
                 readConstantLine("\\*+");
@@ -281,7 +281,7 @@ public class ProjectJobSchedulingImporter extends AbstractTxtSolutionImporter {
                     }
                     if (Integer.parseInt(tokens[0]) != i + 1) {
                         throw new IllegalArgumentException("The tokens (" + Arrays.toString(tokens)
-                                + ") index 0 should be " + (i + 1) +".");
+                                + ") index 0 should be " + (i + 1) + ".");
                     }
                     int executionModeListSize = Integer.parseInt(tokens[1]);
                     List<ExecutionMode> executionModeList = new ArrayList<ExecutionMode>(executionModeListSize);
@@ -324,11 +324,11 @@ public class ProjectJobSchedulingImporter extends AbstractTxtSolutionImporter {
                         String[] tokens = splitBySpacesOrTabs(readStringValue(), (first ? 3 : 2) + resourceSize);
                         if (first && Integer.parseInt(tokens[0]) != i + 1) {
                             throw new IllegalArgumentException("The tokens (" + Arrays.toString(tokens)
-                                    + ") index 0 should be " + (i + 1) +".");
+                                    + ") index 0 should be " + (i + 1) + ".");
                         }
                         if (Integer.parseInt(tokens[first ? 1 : 0]) != j + 1) {
                             throw new IllegalArgumentException("The tokens (" + Arrays.toString(tokens)
-                                    + ") index " + (first ? 1 : 0) + " should be " + (j + 1) +".");
+                                    + ") index " + (first ? 1 : 0) + " should be " + (j + 1) + ".");
                         }
                         int duration = Integer.parseInt(tokens[first ? 2 : 1]);
                         executionMode.setDuration(duration);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/swingui/TennisPanel.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/swingui/TennisPanel.java
@@ -100,7 +100,7 @@ public class TennisPanel extends SolutionPanel {
         int footprintWidth = footprint.getPreferredSize().width;
 
         datesPanel.defineColumnHeaderByKey(HEADER_COLUMN);
-        for (Day day : tennisSolution.getDayList() ) {
+        for (Day day : tennisSolution.getDayList()) {
             datesPanel.defineColumnHeader(day, footprintWidth);
         }
         datesPanel.defineColumnHeaderByKey(TRAILING_HEADER_COLUMN); // Assignment count

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/Visit.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/Visit.java
@@ -29,7 +29,7 @@ import org.optaplanner.examples.tsp.domain.solver.DomicileAngleVisitDifficultyWe
 public class Visit extends AbstractPersistable implements Standstill {
 
     private Location location;
-    
+
     // Planning variables: changes during planning, between score calculations.
     private Standstill previousStandstill;
 

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/persistence/TspImageStipplerImporter.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/persistence/TspImageStipplerImporter.java
@@ -75,7 +75,7 @@ public class TspImageStipplerImporter extends AbstractPngSolutionImporter {
         }
 
         /**
-         * As described by https://en.wikipedia.org/wiki/Floyd%E2%80%93Steinberg_dithering
+         * As described by <a href="https://en.wikipedia.org/wiki/Floyd%E2%80%93Steinberg_dithering">Floyd-Steinberg dithering</a>.
          */
         private void floydSteinbergDithering() {
             travelingSalesmanTour.setDistanceType(DistanceType.AIR_DISTANCE);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/persistence/VehicleRoutingImporter.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/persistence/VehicleRoutingImporter.java
@@ -157,7 +157,7 @@ public class VehicleRoutingImporter extends AbstractTxtSolutionImporter {
             List<HubSegmentLocation> hubLocationList = null;
             locationMap = new LinkedHashMap<Long, Location>(customerListSize);
             if (distanceType == DistanceType.SEGMENTED_ROAD_DISTANCE) {
-                int hubListSize= readIntegerValue("HUBS *:");
+                int hubListSize = readIntegerValue("HUBS *:");
                 hubLocationList = new ArrayList<HubSegmentLocation>(hubListSize);
                 readConstantLine("HUB_COORD_SECTION");
                 for (int i = 0; i < hubListSize; i++) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/swingui/VehicleRoutingSolutionPainter.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/swingui/VehicleRoutingSolutionPainter.java
@@ -101,7 +101,7 @@ public class VehicleRoutingSolutionPainter {
             g.setColor(TangoColorFactory.ALUMINIUM_4);
             g.fillRect(x - 1, y - 1, 3, 3);
             String demandString = Integer.toString(customer.getDemand());
-            g.drawString(demandString, x - (g.getFontMetrics().stringWidth(demandString) / 2), y - TEXT_SIZE/2);
+            g.drawString(demandString, x - (g.getFontMetrics().stringWidth(demandString) / 2), y - TEXT_SIZE / 2);
             if (customer instanceof TimeWindowedCustomer) {
                 TimeWindowedCustomer timeWindowedCustomer = (TimeWindowedCustomer) customer;
                 g.setColor(TangoColorFactory.ALUMINIUM_3);

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/PlannerBenchmarkTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/common/app/PlannerBenchmarkTest.java
@@ -52,7 +52,7 @@ public abstract class PlannerBenchmarkTest extends LoggingTest {
         PlannerBenchmark plannerBenchmark = plannerBenchmarkFactory.buildPlannerBenchmark();
         plannerBenchmark.benchmark();
     }
-    
+
     protected PlannerBenchmarkFactory buildPlannerBenchmarkFactory(File unsolvedDataFile) {
         String benchmarkConfigResource = createBenchmarkConfigResource();
         PlannerBenchmarkFactory benchmarkFactory = PlannerBenchmarkFactory.createFromXmlResource(benchmarkConfigResource);

--- a/pom.xml
+++ b/pom.xml
@@ -76,4 +76,89 @@
     </profile>
   </profiles>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>2.16</version>
+          <executions>
+            <execution>
+              <id>validate</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <configuration>
+                <checkstyleRules>
+                  <module name="Checker">
+                    <property name="severity" value="warning" default="warning"/>
+                    <!-- Checks whether files end with a new line. -->
+                    <module name="NewlineAtEndOfFile">
+                      <property name="lineSeparator" value="lf"/>
+                    </module>
+                    <!-- Checks for whitespace. -->
+                    <module name="FileTabCharacter">
+                      <property name="severity" value="error"/>
+                      <property name="eachLine" value="true"/>
+                    </module>
+                    <module name="TreeWalker">
+                      <property name="cacheFile" value="target/cachefile"/>
+                      <property name="tabWidth" value="4"/>
+                      <!-- Checks for Javadoc comments. -->
+                      <module name="JavadocStyle"/>
+                      <module name="NonEmptyAtclauseDescription"/>
+                      <!-- Checks for imports. -->
+                      <!--<module name="UnusedImports"/>-->
+                      <module name="RedundantImport"/>
+                      <!-- defaults to sun.* packages -->
+                      <module name="IllegalImport"/>
+                      <!-- Checks for size violations. -->
+                      <!--<module name="LineLength">-->
+                      <!--<property name="max" value="120"/>-->
+                      <!--</module>-->
+                      <module name="ParameterNumber"/>
+                      <!-- Checks for whitespace. -->
+                      <module name="GenericWhitespace"/>
+                      <module name="MethodParamPad"/>
+                      <module name="NoWhitespaceBefore"/>
+                      <module name="ParenPad"/>
+                      <module name="TypecastParenPad"/>
+                      <module name="WhitespaceAfter"/>
+                      <module name="WhitespaceAround">
+                        <property name="allowEmptyConstructors" value="true"/>
+                        <property name="allowEmptyTypes" value="true"/>
+                      </module>
+                      <!-- Checks for blocks. -->
+                      <module name="LeftCurly"/>
+                      <module name="NeedBraces"/>
+                      <module name="RightCurly"/>
+                      <!-- Checks for common coding problems. -->
+                      <module name="EmptyStatement"/>
+                      <module name="EqualsHashCode"/>
+                      <module name="IllegalInstantiation"/>
+                      <module name="InnerAssignment"/>
+                      <module name="OneStatementPerLine"/>
+                      <!-- Checks for class design. -->
+                      <!--<module name="HideUtilityClassConstructor"/>-->
+                      <module name="InterfaceIsType"/>
+                      <!-- Miscellaneous other checks. -->
+                      <module name="ArrayTypeStyle"/>
+                      <module name="UpperEll"/>
+                    </module>
+                  </module>
+                </checkstyleRules>
+                <consoleOutput>true</consoleOutput>
+                <logViolationsToConsole>true</logViolationsToConsole>
+                <failOnViolation>true</failOnViolation>
+                <failsOnError>true</failsOnError>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>


### PR DESCRIPTION
Feature proposal:
* Added 25 (+3 out-commented) new modules to the `maven-checkstyle-plugin` (only module currently being run is `FileTabCharacter` which checks for tabs in files)
* All of the modules except for one are run in the warning severity level
  * `FileTabCharacter` is run in severity "error" as in the parent pom
* All errors/warnings/info are reported to the console *(divergent behavior from the parent pom)*
* All modules that fail and have a severity of "error" **fail the build** *(divergent behavior from the parent pom)*
  * Note: currently only one module, `FileTabCharacter`
* Adding/removing modules can be done incrementally as new issues emerge
  * The severity of modules can also be increased/decreased on the go (on a per module basis)
  * **Unfortunately, I have failed at finding modules that correspond with JDK8's javadoc doclint checks**, the only option I see is writing our own, which isn't really satisfactory.
* Does it slow the build? Yes, but not really by much.
  * On an average of 5 runs on my local machine, the complete build (`mvn clean install -Dfull`) runs about 15 seconds slower (which given the ~280s build is about 6%).
  * **Note**: If you don't `clean` between the builds, there is virtually no delay (because of caching)
    * See the logs without `clean` in their name.
  * For details on the benchmark, see [my benchmark script and log](https://gist.github.com/oskopek/ab01b23ee951d3362bcc)
* Currently, checkstyle reports ~100 warnings in the whole project. They're all fixed as part of this PR.
* Also, there's a nice [plugin for IntelliJ](https://github.com/jshiell/checkstyle-idea)