### PR TITLE
examples: run tests in parallel

### DIFF
--- a/optaplanner-examples/pom.xml
+++ b/optaplanner-examples/pom.xml
@@ -43,6 +43,13 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <forkCount>0.5C</forkCount>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <!-- WARNING: This configuration must be run with "mvn exec:java" not "mvn exec:exec". -->


### PR DESCRIPTION
* just a suggestion. Tested locally without any test failures. 

* 4 seems like a good number given current processors have 2-4 cores. We could even use something like 2C (two threads per core). But this gets tricky when using e.g. Hyper Threading, because the number of cores visible to surefire is doubled, so in the end we have 4 threads per one "real" core.

 * adding it only to `-examples` as this module takes by far the most time and contains most of the tests

 * locally, the speedup is about 33% (from 3 min to 2 min)