### PR TITLE
PLANNER-391-refactor: Changed rank number if solvers are to be equally ranked

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/PlannerBenchmarkResult.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/PlannerBenchmarkResult.java
@@ -320,10 +320,11 @@ public class PlannerBenchmarkResult {
                 benchmarkReport, rankableSolverBenchmarkResultList);
         int ranking = 0;
         for (List<SolverBenchmarkResult> sameRankingList : sameRankingListList) {
+            ranking += sameRankingList.size() - 1;
             for (SolverBenchmarkResult solverBenchmarkResult : sameRankingList) {
                 solverBenchmarkResult.setRanking(ranking);
             }
-            ranking += sameRankingList.size();
+            ranking++;
         }
         favoriteSolverBenchmarkResult = sameRankingListList.isEmpty() ? null
                 : sameRankingListList.get(0).get(0);

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SolverBenchmarkResult.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SolverBenchmarkResult.java
@@ -57,6 +57,8 @@ public class SolverBenchmarkResult {
     // ************************************************************************
 
     private Integer failureCount = null;
+    private Integer uninitializedSolutionCount = null;
+    private Integer infeasibleScoreCount = null;
     private Score totalScore = null;
     private Score averageScore = null;
     // Not a Score because
@@ -113,6 +115,14 @@ public class SolverBenchmarkResult {
 
     public Integer getFailureCount() {
         return failureCount;
+    }
+
+    public Integer getUninitializedSolutionCount() {
+        return uninitializedSolutionCount;
+    }
+
+    public Integer getInfeasibleScoreCount() {
+        return infeasibleScoreCount;
     }
 
     public Score getTotalScore() {
@@ -172,6 +182,14 @@ public class SolverBenchmarkResult {
 
     public boolean hasAnyFailure() {
         return failureCount > 0;
+    }
+
+    public boolean hasAnyUninitializedSolution() {
+        return uninitializedSolutionCount > 0;
+    }
+
+    public boolean hasAnyInfeasibleScore() {
+        return infeasibleScoreCount > 0;
     }
 
     public boolean isFavorite() {
@@ -262,10 +280,17 @@ public class SolverBenchmarkResult {
         ScoreDifferencePercentage totalWorstScoreDifferencePercentage = null;
         long totalAverageCalculateCountPerSecond = 0L;
         long totalTimeMillisSpent = 0L;
+        uninitializedSolutionCount = 0;
+        infeasibleScoreCount = 0;
         for (SingleBenchmarkResult singleBenchmarkResult : singleBenchmarkResultList) {
             if (singleBenchmarkResult.isFailure()) {
                 failureCount++;
             } else {
+                if (!singleBenchmarkResult.isInitialized()) {
+                    uninitializedSolutionCount++;
+                } else if (!singleBenchmarkResult.isScoreFeasible()) {
+                    infeasibleScoreCount++;
+                }
                 if (firstNonFailure) {
                     totalScore = singleBenchmarkResult.getScore();
                     totalWinningScoreDifference = singleBenchmarkResult.getWinningScoreDifference();

--- a/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
+++ b/optaplanner-benchmark/src/main/resources/org/optaplanner/benchmark/impl/report/benchmarkReport.html.ftl
@@ -15,16 +15,24 @@
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 </head>
-<#macro addSolverRankingBadge solverBenchmarkResult>
+<#macro addSolverBenchmarkBadges solverBenchmarkResult>
     <#if !solverBenchmarkResult.ranking??>
         <span class="badge badge-important" data-toggle="tooltip" title="Failed benchmark">F</span>
-    <#elseif solverBenchmarkResult.favorite>
-        <span class="badge badge-success">${solverBenchmarkResult.ranking}</span>
     <#else>
-        <span class="badge">${solverBenchmarkResult.ranking}</span>
+        <#if solverBenchmarkResult.favorite>
+            <span class="badge badge-success">${solverBenchmarkResult.ranking}</span>
+        <#else>
+            <span class="badge">${solverBenchmarkResult.ranking}</span>
+        </#if>
+
+        <#if solverBenchmarkResult.hasAnyUninitializedSolution()>
+            <span class="badge badge-important" data-toggle="tooltip" title="Has an uninitialized solution">!</span>
+        <#elseif solverBenchmarkResult.hasAnyInfeasibleScore()>
+            <span class="badge badge-warning" data-toggle="tooltip" title="Has an infeasible score">!</span>
+        </#if>
     </#if>
 </#macro>
-<#macro addSingleRankingBadge singleBenchmarkResult>
+<#macro addSingleBenchmarkBadges singleBenchmarkResult>
     <#if !singleBenchmarkResult.ranking??>
         <span class="badge badge-important" data-toggle="tooltip" title="Failed benchmark">F</span>
     <#else>
@@ -99,7 +107,7 @@
                         <li>
                             <ul class="nav nav-list">
                             <#list benchmarkReport.plannerBenchmarkResult.solverBenchmarkResultList as solverBenchmarkResult>
-                                <li><a href="#solverBenchmark_${solverBenchmarkResult.anchorId}">${solverBenchmarkResult.name}&nbsp;<@addSolverRankingBadge solverBenchmarkResult=solverBenchmarkResult/></a></li>
+                                <li><a href="#solverBenchmark_${solverBenchmarkResult.anchorId}">${solverBenchmarkResult.name}&nbsp;<@addSolverBenchmarkBadges solverBenchmarkResult=solverBenchmarkResult/></a></li>
                             </#list>
                             </ul>
                         </li>
@@ -165,7 +173,7 @@
                                     </tr>
                                 <#list benchmarkReport.plannerBenchmarkResult.solverBenchmarkResultList as solverBenchmarkResult>
                                     <tr<#if solverBenchmarkResult.favorite> class="favoriteSolverBenchmark"</#if>>
-                                        <th>${solverBenchmarkResult.name}&nbsp;<@addSolverRankingBadge solverBenchmarkResult=solverBenchmarkResult/></th>
+                                        <th>${solverBenchmarkResult.name}&nbsp;<@addSolverBenchmarkBadges solverBenchmarkResult=solverBenchmarkResult/></th>
                                         <td>${solverBenchmarkResult.totalScore!""}</td>
                                         <td>${solverBenchmarkResult.averageScore!""}</td>
                                         <td>${solverBenchmarkResult.standardDeviationString!""}</td>
@@ -177,7 +185,7 @@
                                                 <#if !singleBenchmarkResult.success>
                                                     <td><span class="label label-important">Failed</span></td>
                                                 <#else>
-                                                    <td>${singleBenchmarkResult.score}&nbsp;<@addSingleRankingBadge singleBenchmarkResult=singleBenchmarkResult/></td>
+                                                    <td>${singleBenchmarkResult.score}&nbsp;<@addSingleBenchmarkBadges singleBenchmarkResult=singleBenchmarkResult/></td>
                                                 </#if>
                                             </#if>
                                         </#list>
@@ -208,7 +216,7 @@
                                     </tr>
                                 <#list benchmarkReport.plannerBenchmarkResult.solverBenchmarkResultList as solverBenchmarkResult>
                                     <tr<#if solverBenchmarkResult.favorite> class="favoriteSolverBenchmark"</#if>>
-                                        <th>${solverBenchmarkResult.name}&nbsp;<@addSolverRankingBadge solverBenchmarkResult=solverBenchmarkResult/></th>
+                                        <th>${solverBenchmarkResult.name}&nbsp;<@addSolverBenchmarkBadges solverBenchmarkResult=solverBenchmarkResult/></th>
                                         <td>${solverBenchmarkResult.totalWinningScoreDifference!""}</td>
                                         <td>${solverBenchmarkResult.averageWinningScoreDifference!""}</td>
                                         <#list benchmarkReport.plannerBenchmarkResult.unifiedProblemBenchmarkResultList as problemBenchmarkResult>
@@ -219,7 +227,7 @@
                                                 <#if !singleBenchmarkResult.success>
                                                     <td><span class="label label-important">Failed</span></td>
                                                 <#else>
-                                                    <td>${singleBenchmarkResult.winningScoreDifference}&nbsp;<@addSingleRankingBadge singleBenchmarkResult=singleBenchmarkResult/></td>
+                                                    <td>${singleBenchmarkResult.winningScoreDifference}&nbsp;<@addSingleBenchmarkBadges singleBenchmarkResult=singleBenchmarkResult/></td>
                                                 </#if>
                                             </#if>
                                         </#list>
@@ -244,7 +252,7 @@
                                     </tr>
                                 <#list benchmarkReport.plannerBenchmarkResult.solverBenchmarkResultList as solverBenchmarkResult>
                                     <tr<#if solverBenchmarkResult.favorite> class="favoriteSolverBenchmark"</#if>>
-                                        <th>${solverBenchmarkResult.name}&nbsp;<@addSolverRankingBadge solverBenchmarkResult=solverBenchmarkResult/></th>
+                                        <th>${solverBenchmarkResult.name}&nbsp;<@addSolverBenchmarkBadges solverBenchmarkResult=solverBenchmarkResult/></th>
                                         <#if !solverBenchmarkResult.averageWorstScoreDifferencePercentage??>
                                             <td></td>
                                         <#else>
@@ -258,7 +266,7 @@
                                                 <#if !singleBenchmarkResult.success>
                                                     <td><span class="label label-important">Failed</span></td>
                                                 <#else>
-                                                    <td>${singleBenchmarkResult.worstScoreDifferencePercentage.toString(.locale)}&nbsp;<@addSingleRankingBadge singleBenchmarkResult=singleBenchmarkResult/></td>
+                                                    <td>${singleBenchmarkResult.worstScoreDifferencePercentage.toString(.locale)}&nbsp;<@addSingleBenchmarkBadges singleBenchmarkResult=singleBenchmarkResult/></td>
                                                 </#if>
                                             </#if>
                                         </#list>
@@ -333,7 +341,7 @@
                                     </tr>
                                 <#list benchmarkReport.plannerBenchmarkResult.solverBenchmarkResultList as solverBenchmarkResult>
                                     <tr<#if solverBenchmarkResult.favorite> class="favoriteSolverBenchmark"</#if>>
-                                        <th>${solverBenchmarkResult.name}&nbsp;<@addSolverRankingBadge solverBenchmarkResult=solverBenchmarkResult/></th>
+                                        <th>${solverBenchmarkResult.name}&nbsp;<@addSolverBenchmarkBadges solverBenchmarkResult=solverBenchmarkResult/></th>
                                         <td>${solverBenchmarkResult.averageAverageCalculateCountPerSecond!""}/s</td>
                                         <#list benchmarkReport.plannerBenchmarkResult.unifiedProblemBenchmarkResultList as problemBenchmarkResult>
                                             <#if !solverBenchmarkResult.findSingleBenchmark(problemBenchmarkResult)??>
@@ -377,7 +385,7 @@
                                     </tr>
                                 <#list benchmarkReport.plannerBenchmarkResult.solverBenchmarkResultList as solverBenchmarkResult>
                                     <tr<#if solverBenchmarkResult.favorite> class="favoriteSolverBenchmark"</#if>>
-                                        <th>${solverBenchmarkResult.name}&nbsp;<@addSolverRankingBadge solverBenchmarkResult=solverBenchmarkResult/></th>
+                                        <th>${solverBenchmarkResult.name}&nbsp;<@addSolverBenchmarkBadges solverBenchmarkResult=solverBenchmarkResult/></th>
                                         <td>${solverBenchmarkResult.averageTimeMillisSpent!""}</td>
                                         <#list benchmarkReport.plannerBenchmarkResult.unifiedProblemBenchmarkResultList as problemBenchmarkResult>
                                             <#if !solverBenchmarkResult.findSingleBenchmark(problemBenchmarkResult)??>
@@ -567,7 +575,7 @@
                 </div>
             <#list benchmarkReport.plannerBenchmarkResult.solverBenchmarkResultList as solverBenchmarkResult>
                 <section id="solverBenchmark_${solverBenchmarkResult.anchorId}">
-                    <h2>${solverBenchmarkResult.name}&nbsp;<@addSolverRankingBadge solverBenchmarkResult=solverBenchmarkResult/></h2>
+                    <h2>${solverBenchmarkResult.name}&nbsp;<@addSolverBenchmarkBadges solverBenchmarkResult=solverBenchmarkResult/></h2>
                     <#if solverBenchmarkResult.hasAnyFailure()>
                         <div class="alert alert-error">
                             <p>${solverBenchmarkResult.failureCount} benchmarks have failed!</p>


### PR DESCRIPTION
* Instead of numbering equal solver with the highest possible rank, number them with the lowest possible rank.
  * Example: if two solver configs are to be ranked after three better solver configs, their rank numbers would be: 0, 1, 2, 4, 4. Originally: 0, 1, 2, 3, 3.
* This is just a cosmetic touch and not important, also depends on personal preference. I personally found the numbering to be more logical this way. Open to discussion/closing the PR.
* **NOTE**: Merge after PLANNER-390 PR #119 **and** PLANNER-391 PR #120