### PR TITLE
PLANNER-391: Show uninitialized score in swingui

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java
@@ -44,6 +44,7 @@ import org.optaplanner.core.impl.heuristic.selector.move.generic.chained.Chained
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 import org.optaplanner.core.impl.score.director.ScoreDirectorFactory;
+import org.optaplanner.core.impl.solver.DefaultSolver;
 import org.optaplanner.core.impl.solver.ProblemFactChange;
 import org.optaplanner.examples.common.app.CommonApp;
 import org.optaplanner.examples.common.persistence.AbstractSolutionExporter;
@@ -199,8 +200,22 @@ public class SolutionBusiness {
         return solutionFileName;
     }
 
+    public int getUninitializedVariableCount() {
+        if (solver instanceof DefaultSolver) {
+            return ((DefaultSolver) solver).getSolverScope().getBestUninitializedVariableCount();
+        }
+        return 0;
+    }
+
     public Score getScore() {
         return guiScoreDirector.calculateScore();
+    }
+
+    public String getScoreWithUninitializedPrefix() {
+        if (solver instanceof DefaultSolver) {
+            return ((DefaultSolver) solver).getSolverScope().getBestScoreWithUninitializedPrefix();
+        }
+        return getScore().toString();
     }
 
     public boolean isSolving() {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/business/SolutionBusiness.java
@@ -201,6 +201,7 @@ public class SolutionBusiness {
     }
 
     public int getUninitializedVariableCount() {
+        // TODO Remove after fixing https://issues.jboss.org/browse/PLANNER-405
         if (solver instanceof DefaultSolver) {
             return ((DefaultSolver) solver).getSolverScope().getBestUninitializedVariableCount();
         }
@@ -212,6 +213,7 @@ public class SolutionBusiness {
     }
 
     public String getScoreWithUninitializedPrefix() {
+        // TODO Remove after fixing https://issues.jboss.org/browse/PLANNER-405
         if (solver instanceof DefaultSolver) {
             return ((DefaultSolver) solver).getSolverScope().getBestScoreWithUninitializedPrefix();
         }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/SolverAndPersistenceFrame.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/SolverAndPersistenceFrame.java
@@ -599,6 +599,7 @@ public class SolverAndPersistenceFrame extends JFrame {
     }
 
     public void refreshScoreField(Solution solution) {
+        // TODO Fix after https://issues.jboss.org/browse/PLANNER-405
         scoreField.setForeground(determineScoreFieldForeground(solutionBusiness.getUninitializedVariableCount(), solution.getScore()));
         scoreField.setText("Latest best score: " + solutionBusiness.getScoreWithUninitializedPrefix());
     }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/SolverAndPersistenceFrame.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/SolverAndPersistenceFrame.java
@@ -599,16 +599,19 @@ public class SolverAndPersistenceFrame extends JFrame {
     }
 
     public void refreshScoreField(Solution solution) {
-        scoreField.setForeground(determineScoreFieldForeground(solution.getScore()));
-        scoreField.setText("Latest best score: " + solution.getScore());
+        scoreField.setForeground(determineScoreFieldForeground(solutionBusiness.getUninitializedVariableCount(), solution.getScore()));
+        scoreField.setText("Latest best score: " + solutionBusiness.getScoreWithUninitializedPrefix());
     }
 
-    private Color determineScoreFieldForeground(Score<?> score) {
-        if (!(score instanceof FeasibilityScore)) {
+    private Color determineScoreFieldForeground(int uninitializedVariableCount, Score<?> score) {
+        if (uninitializedVariableCount > 0) {
+            return TangoColorFactory.SCARLET_3;
+        }
+        else if (!(score instanceof FeasibilityScore)) {
             return Color.BLACK;
         } else {
             FeasibilityScore<?> feasibilityScore = (FeasibilityScore<?>) score;
-            return feasibilityScore.isFeasible() ? TangoColorFactory.CHAMELEON_3 : TangoColorFactory.SCARLET_3;
+            return feasibilityScore.isFeasible() ? TangoColorFactory.CHAMELEON_3 : TangoColorFactory.ORANGE_3;
         }
     }
 


### PR DESCRIPTION
Didn't find any place where the Swing UI would use an "uninitialized" score prefix, so I added it (not very cleanly with all the casts, I must admit). The colors were changed to correspond with the usage in the benchmarker.