### PR TITLE
PLANNER-259: Persist SingleStatistic point lists to save memory

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SingleBenchmarkRunner.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SingleBenchmarkRunner.java
@@ -77,7 +77,7 @@ public class SingleBenchmarkRunner implements Callable<SingleBenchmarkRunner> {
 
         for (SingleStatistic singleStatistic : singleBenchmarkResult.getEffectiveSingleStatisticMap().values()) {
             singleStatistic.open(solver);
-            singleStatistic.unhibernatePointList();
+            singleStatistic.initPointList();
         }
 
         solver.solve(inputSolution);

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SingleBenchmarkRunner.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SingleBenchmarkRunner.java
@@ -77,6 +77,7 @@ public class SingleBenchmarkRunner implements Callable<SingleBenchmarkRunner> {
 
         for (SingleStatistic singleStatistic : singleBenchmarkResult.getEffectiveSingleStatisticMap().values()) {
             singleStatistic.open(solver);
+            singleStatistic.retrievePointList();
         }
 
         solver.solve(inputSolution);
@@ -95,7 +96,7 @@ public class SingleBenchmarkRunner implements Callable<SingleBenchmarkRunner> {
 
         for (SingleStatistic singleStatistic : singleBenchmarkResult.getEffectiveSingleStatisticMap().values()) {
             singleStatistic.close(solver);
-            singleStatistic.writeCsvStatisticFile();
+            singleStatistic.persistPointList();
         }
         problemBenchmarkResult.writeOutputSolution(singleBenchmarkResult, outputSolution);
         MDC.remove(NAME_MDC);

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SingleBenchmarkRunner.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/SingleBenchmarkRunner.java
@@ -77,7 +77,7 @@ public class SingleBenchmarkRunner implements Callable<SingleBenchmarkRunner> {
 
         for (SingleStatistic singleStatistic : singleBenchmarkResult.getEffectiveSingleStatisticMap().values()) {
             singleStatistic.open(solver);
-            singleStatistic.retrievePointList();
+            singleStatistic.unhibernatePointList();
         }
 
         solver.solve(inputSolution);
@@ -96,7 +96,7 @@ public class SingleBenchmarkRunner implements Callable<SingleBenchmarkRunner> {
 
         for (SingleStatistic singleStatistic : singleBenchmarkResult.getEffectiveSingleStatisticMap().values()) {
             singleStatistic.close(solver);
-            singleStatistic.persistPointList();
+            singleStatistic.hibernatePointList();
         }
         problemBenchmarkResult.writeOutputSolution(singleBenchmarkResult, outputSolution);
         MDC.remove(NAME_MDC);

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/BenchmarkAggregator.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/BenchmarkAggregator.java
@@ -81,9 +81,6 @@ public class BenchmarkAggregator {
         Date startingTimestamp = new Date();
         for (SingleBenchmarkResult singleBenchmarkResult : singleBenchmarkResultList) {
             singleBenchmarkResult.initSingleStatisticMap();
-            for (SingleStatistic singleStatistic : singleBenchmarkResult.getEffectiveSingleStatisticMap().values()) {
-                singleStatistic.unhibernatePointList();
-            }
         }
         // Handle renamed solver benchmarks after statistics have been read (they're resolved by
         // original solver benchmarks' names)

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/BenchmarkAggregator.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/BenchmarkAggregator.java
@@ -82,7 +82,7 @@ public class BenchmarkAggregator {
         for (SingleBenchmarkResult singleBenchmarkResult : singleBenchmarkResultList) {
             singleBenchmarkResult.initSingleStatisticMap();
             for (SingleStatistic singleStatistic : singleBenchmarkResult.getEffectiveSingleStatisticMap().values()) {
-                singleStatistic.readCsvStatisticFile();
+                singleStatistic.retrievePointList();
             }
         }
         // Handle renamed solver benchmarks after statistics have been read (they're resolved by

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/BenchmarkAggregator.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/aggregator/BenchmarkAggregator.java
@@ -82,7 +82,7 @@ public class BenchmarkAggregator {
         for (SingleBenchmarkResult singleBenchmarkResult : singleBenchmarkResultList) {
             singleBenchmarkResult.initSingleStatisticMap();
             for (SingleStatistic singleStatistic : singleBenchmarkResult.getEffectiveSingleStatisticMap().values()) {
-                singleStatistic.retrievePointList();
+                singleStatistic.unhibernatePointList();
             }
         }
         // Handle renamed solver benchmarks after statistics have been read (they're resolved by

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
@@ -228,9 +228,10 @@ public class BenchmarkReport {
                     for (SingleStatistic singleStatistic : problemStatistic.getSingleStatisticList()) {
                         try {
                             singleStatistic.unhibernatePointList();
-                        } catch (IllegalStateException ise) {
+                        } catch (IllegalStateException e) {
                             if (!plannerBenchmarkResult.getAggregation()) {
-                                throw ise;
+                                throw new IllegalStateException("Failed to unhibernate point list of SingleStatistic ( "
+                                        + singleStatistic + " ) of ProblemStatistic ( " + problemStatistic + " ).", e);
                             }
                             logger.trace("This is expected, aggregator doesn't copy CSV files. Could not read CSV file "
                                     + "( {} ) of single statistic ( {} ).", singleStatistic.getCsvFile().getAbsolutePath(), singleStatistic);
@@ -250,9 +251,10 @@ public class BenchmarkReport {
                         for (PureSingleStatistic pureSingleStatistic : singleBenchmarkResult.getPureSingleStatisticList()) {
                             try {
                                 pureSingleStatistic.unhibernatePointList();
-                            } catch (IllegalStateException ise) {
+                            } catch (IllegalStateException e) {
                                 if (!plannerBenchmarkResult.getAggregation()) {
-                                    throw ise;
+                                    throw new IllegalStateException("Failed to unhibernate point list of "
+                                            + "PureSingleStatistic ( " + pureSingleStatistic + " ).", e);
                                 }
                                 logger.trace("This is expected, aggregator doesn't copy CSV files. Could not read CSV file "
                                         + "( {} ) of pure single statistic ( {} ).", pureSingleStatistic.getCsvFile().getAbsolutePath(), pureSingleStatistic);

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
@@ -237,6 +237,13 @@ public class BenchmarkReport {
                         }
                     }
                     problemStatistic.writeGraphFiles(this);
+                    for (SingleStatistic singleStatistic : problemStatistic.getSingleStatisticList()) {
+                        if (plannerBenchmarkResult.getAggregation()) {
+                            singleStatistic.setPointList(null);
+                        } else {
+                            singleStatistic.hibernatePointList();
+                        }
+                    }
                 }
                 for (SingleBenchmarkResult singleBenchmarkResult : problemBenchmarkResult.getSingleBenchmarkResultList()) {
                     if (singleBenchmarkResult.isSuccess()) {
@@ -251,6 +258,11 @@ public class BenchmarkReport {
                                         + "( {} ) of pure single statistic ( {} ).", pureSingleStatistic.getCsvFile().getAbsolutePath(), pureSingleStatistic);
                             }
                             pureSingleStatistic.writeGraphFiles(this);
+                            if (plannerBenchmarkResult.getAggregation()) {
+                                pureSingleStatistic.setPointList(null);
+                            } else {
+                                pureSingleStatistic.hibernatePointList();
+                            }
                         }
                     }
                 }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
@@ -64,6 +64,7 @@ import org.optaplanner.benchmark.impl.result.SingleBenchmarkResult;
 import org.optaplanner.benchmark.impl.result.SolverBenchmarkResult;
 import org.optaplanner.benchmark.impl.statistic.ProblemStatistic;
 import org.optaplanner.benchmark.impl.statistic.PureSingleStatistic;
+import org.optaplanner.benchmark.impl.statistic.SingleStatistic;
 import org.optaplanner.benchmark.impl.statistic.common.MillisecondsSpentNumberFormat;
 import org.optaplanner.core.impl.score.ScoreUtils;
 
@@ -220,11 +221,15 @@ public class BenchmarkReport {
         for (ProblemBenchmarkResult problemBenchmarkResult : plannerBenchmarkResult.getUnifiedProblemBenchmarkResultList()) {
             if (problemBenchmarkResult.hasAnySuccess()) {
                 for (ProblemStatistic problemStatistic : problemBenchmarkResult.getProblemStatisticList()) {
+                    for (SingleStatistic singleStatistic : problemStatistic.getSingleStatisticList()) {
+                        singleStatistic.retrievePointList();
+                    }
                     problemStatistic.writeGraphFiles(this);
                 }
                 for (SingleBenchmarkResult singleBenchmarkResult : problemBenchmarkResult.getSingleBenchmarkResultList()) {
                     if (singleBenchmarkResult.isSuccess()) {
                         for (PureSingleStatistic pureSingleStatistic : singleBenchmarkResult.getPureSingleStatisticList()) {
+                            pureSingleStatistic.retrievePointList();
                             pureSingleStatistic.writeGraphFiles(this);
                         }
                     }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/report/BenchmarkReport.java
@@ -222,14 +222,14 @@ public class BenchmarkReport {
             if (problemBenchmarkResult.hasAnySuccess()) {
                 for (ProblemStatistic problemStatistic : problemBenchmarkResult.getProblemStatisticList()) {
                     for (SingleStatistic singleStatistic : problemStatistic.getSingleStatisticList()) {
-                        singleStatistic.retrievePointList();
+                        singleStatistic.unhibernatePointList();
                     }
                     problemStatistic.writeGraphFiles(this);
                 }
                 for (SingleBenchmarkResult singleBenchmarkResult : problemBenchmarkResult.getSingleBenchmarkResultList()) {
                     if (singleBenchmarkResult.isSuccess()) {
                         for (PureSingleStatistic pureSingleStatistic : singleBenchmarkResult.getPureSingleStatisticList()) {
-                            pureSingleStatistic.retrievePointList();
+                            pureSingleStatistic.unhibernatePointList();
                             pureSingleStatistic.writeGraphFiles(this);
                         }
                     }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/BenchmarkResultIO.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/BenchmarkResultIO.java
@@ -123,19 +123,6 @@ public class BenchmarkResultIO {
     }
 
     private void restoreOmittedBidirectionalFields(PlannerBenchmarkResult plannerBenchmarkResult) {
-        for (SolverBenchmarkResult solverBenchmarkResult : plannerBenchmarkResult.getSolverBenchmarkResultList()) {
-            solverBenchmarkResult.setPlannerBenchmarkResult(plannerBenchmarkResult);
-            for (SingleBenchmarkResult singleBenchmarkResult : solverBenchmarkResult.getSingleBenchmarkResultList()) {
-                singleBenchmarkResult.setSolverBenchmarkResult(solverBenchmarkResult);
-                if (singleBenchmarkResult.getPureSingleStatisticList() == null) {
-                    singleBenchmarkResult.setPureSingleStatisticList(new ArrayList<PureSingleStatistic>(0));
-                }
-                for (PureSingleStatistic pureSingleStatistic : singleBenchmarkResult.getPureSingleStatisticList()) {
-                    pureSingleStatistic.setSingleBenchmarkResult(singleBenchmarkResult);
-                    pureSingleStatistic.initPointList();
-                }
-            }
-        }
         for (ProblemBenchmarkResult problemBenchmarkResult : plannerBenchmarkResult.getUnifiedProblemBenchmarkResultList()) {
             problemBenchmarkResult.setPlannerBenchmarkResult(plannerBenchmarkResult);
             if (problemBenchmarkResult.getProblemStatisticList() == null) {
@@ -146,6 +133,18 @@ public class BenchmarkResultIO {
             }
             for (SingleBenchmarkResult singleBenchmarkResult : problemBenchmarkResult.getSingleBenchmarkResultList()) {
                 singleBenchmarkResult.setProblemBenchmarkResult(problemBenchmarkResult);
+            }
+        }
+        for (SolverBenchmarkResult solverBenchmarkResult : plannerBenchmarkResult.getSolverBenchmarkResultList()) {
+            solverBenchmarkResult.setPlannerBenchmarkResult(plannerBenchmarkResult);
+            for (SingleBenchmarkResult singleBenchmarkResult : solverBenchmarkResult.getSingleBenchmarkResultList()) {
+                singleBenchmarkResult.setSolverBenchmarkResult(solverBenchmarkResult);
+                if (singleBenchmarkResult.getPureSingleStatisticList() == null) {
+                    singleBenchmarkResult.setPureSingleStatisticList(new ArrayList<PureSingleStatistic>(0));
+                }
+                for (PureSingleStatistic pureSingleStatistic : singleBenchmarkResult.getPureSingleStatisticList()) {
+                    pureSingleStatistic.setSingleBenchmarkResult(singleBenchmarkResult);
+                }
             }
         }
     }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemBasedSingleStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemBasedSingleStatistic.java
@@ -34,4 +34,9 @@ public abstract class ProblemBasedSingleStatistic<P extends StatisticPoint> exte
         return problemStatisticType;
     }
 
+    @Override
+    public String toString() {
+        return singleBenchmarkResult.toString() + "_" + problemStatisticType.toString();
+    }
+
 }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemBasedSingleStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemBasedSingleStatistic.java
@@ -36,7 +36,7 @@ public abstract class ProblemBasedSingleStatistic<P extends StatisticPoint> exte
 
     @Override
     public String toString() {
-        return singleBenchmarkResult.toString() + "_" + problemStatisticType.toString();
+        return singleBenchmarkResult + "_" + problemStatisticType;
     }
 
 }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemStatistic.java
@@ -138,7 +138,7 @@ public abstract class ProblemStatistic {
 
     @Override
     public String toString() {
-        return problemBenchmarkResult.toString() + "_" + problemStatisticType.toString();
+        return problemBenchmarkResult + "_" + problemStatisticType;
     }
 
 }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/ProblemStatistic.java
@@ -136,4 +136,9 @@ public abstract class ProblemStatistic {
 
     public abstract List<File> getGraphFileList();
 
+    @Override
+    public String toString() {
+        return problemBenchmarkResult.toString() + "_" + problemStatisticType.toString();
+    }
+
 }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/PureSingleStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/PureSingleStatistic.java
@@ -80,4 +80,9 @@ public abstract class PureSingleStatistic<P extends StatisticPoint> extends Sing
 
     public abstract List<File> getGraphFileList();
 
+    @Override
+    public String toString() {
+        return singleBenchmarkResult.toString() + "_" + singleStatisticType.toString();
+    }
+
 }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/PureSingleStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/PureSingleStatistic.java
@@ -82,7 +82,7 @@ public abstract class PureSingleStatistic<P extends StatisticPoint> extends Sing
 
     @Override
     public String toString() {
-        return singleBenchmarkResult.toString() + "_" + singleStatisticType.toString();
+        return singleBenchmarkResult + "_" + singleStatisticType;
     }
 
 }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/SingleStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/SingleStatistic.java
@@ -185,14 +185,14 @@ public abstract class SingleStatistic<P extends StatisticPoint> {
         }
     }
 
-    public void retrievePointList() {
+    public void unhibernatePointList() {
         if (getCsvFile().exists() && pointList == null) {
             initPointList();
             readCsvStatisticFile();
         }
     }
 
-    public void persistPointList() {
+    public void hibernatePointList() {
         writeCsvStatisticFile();
         pointList = null;
     }

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/SingleStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/SingleStatistic.java
@@ -105,7 +105,7 @@ public abstract class SingleStatistic<P extends StatisticPoint> {
 
     protected abstract String getCsvHeader();
 
-    public void writeCsvStatisticFile() {
+    private void writeCsvStatisticFile() {
         File csvFile = getCsvFile();
         Writer writer = null;
         try {
@@ -124,7 +124,7 @@ public abstract class SingleStatistic<P extends StatisticPoint> {
         }
     }
 
-    public void readCsvStatisticFile() {
+    private void readCsvStatisticFile() {
         File csvFile = getCsvFile();
         ScoreDefinition scoreDefinition = singleBenchmarkResult.getSolverBenchmarkResult().getSolverConfig()
                 .getScoreDirectorFactoryConfig().buildScoreDefinition();
@@ -183,6 +183,18 @@ public abstract class SingleStatistic<P extends StatisticPoint> {
         } finally {
             IOUtils.closeQuietly(reader);
         }
+    }
+
+    public void retrievePointList() {
+        if (getCsvFile().exists() && pointList == null) {
+            initPointList();
+            readCsvStatisticFile();
+        }
+    }
+
+    public void persistPointList() {
+        writeCsvStatisticFile();
+        pointList = null;
     }
 
     protected abstract P createPointFromCsvLine(ScoreDefinition scoreDefinition, List<String> csvLine);

--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/SingleStatistic.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/statistic/SingleStatistic.java
@@ -59,7 +59,6 @@ public abstract class SingleStatistic<P extends StatisticPoint> {
 
     protected SingleStatistic(SingleBenchmarkResult singleBenchmarkResult) {
         this.singleBenchmarkResult = singleBenchmarkResult;
-        initPointList();
     }
 
     public SingleBenchmarkResult getSingleBenchmarkResult() {
@@ -186,10 +185,15 @@ public abstract class SingleStatistic<P extends StatisticPoint> {
     }
 
     public void unhibernatePointList() {
-        if (getCsvFile().exists() && pointList == null) {
-            initPointList();
-            readCsvStatisticFile();
+        if (!getCsvFile().exists()) {
+            throw new IllegalStateException("The csvFile ( " + getCsvFile() + " ) of the statistic ( " + getStatisticType()
+                    + " ) of the single benchmark ( " + singleBenchmarkResult + " ) doesn't exist.");
+        } else if (pointList != null) {
+            throw new IllegalStateException("The pointList ( " + pointList + " ) of the statistic ( " + getStatisticType()
+                    + " ) of the single benchmark ( " + singleBenchmarkResult + " ) should be null when unhibernating.");
         }
+        initPointList();
+        readCsvStatisticFile();
     }
 
     public void hibernatePointList() {


### PR DESCRIPTION
* On longer benchmark runs with a large count of single statistics, the memory savings can be quite large: about 20MB per statistic per single benchmark (the number is not accurate at all). See JIRA attached screenshots.
* The toll for the memory optimization comes at the end, when generating the report: There is a ~11% slow down (about 17 seconds) in a very big benchmark (61 single benchmarks, 10min each).