### PR TITLE
FIX: SolverBenchmarkResult Correct failed singles handling in average score with uninitialized prefix

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SolverBenchmarkResult.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/impl/result/SolverBenchmarkResult.java
@@ -269,6 +269,9 @@ public class SolverBenchmarkResult {
     }
 
     public String getAverageScoreWithUninitializedPrefix() {
+        if (getSuccessCount() == 0) {
+            return null; // return null, not String "null" so we can use a default value
+        }
         return ScoreUtils.getScoreWithUninitializedPrefix(
                 ConfigUtils.ceilDivide(getTotalUninitializedVariableCount(), getSuccessCount()),
                 getAverageScore());

--- a/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/result/SolverBenchmarkResultTest.java
+++ b/optaplanner-benchmark/src/test/java/org/optaplanner/benchmark/impl/result/SolverBenchmarkResultTest.java
@@ -59,15 +59,7 @@ public class SolverBenchmarkResultTest {
         assertEquals("2uninitialized/-10hard/-100soft", solverBenchmarkResult.getAverageScoreWithUninitializedPrefix());
         when(solverBenchmarkResult.getFailureCount()).thenReturn(0);
         assertEquals("1uninitialized/-10hard/-100soft", solverBenchmarkResult.getAverageScoreWithUninitializedPrefix());
-    }
-
-    @Test(expected = ArithmeticException.class)
-    public void testZeroDivisorGetAverageScoreWithUninitializedPrefix() throws Exception {
-        SolverBenchmarkResult solverBenchmarkResult = spy(new SolverBenchmarkResult(null));
-        when(solverBenchmarkResult.getSingleBenchmarkResultList()).thenReturn(Collections.<SingleBenchmarkResult>emptyList());
-        when(solverBenchmarkResult.getAverageScore()).thenReturn(HardSoftScore.valueOf(-10, -100));
-        when(solverBenchmarkResult.getTotalUninitializedVariableCount()).thenReturn(0);
-        when(solverBenchmarkResult.getFailureCount()).thenReturn(0);
-        solverBenchmarkResult.getAverageScoreWithUninitializedPrefix();
+        when(solverBenchmarkResult.getFailureCount()).thenReturn(2);
+        assertEquals(null, solverBenchmarkResult.getAverageScoreWithUninitializedPrefix());
     }
 }


### PR DESCRIPTION
Very sorry for breaking the build with #145. This will fix it.