### PR TITLE
Fix asciidoctor complaints in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 image:https://jenkins-kieci.rhcloud.com/buildStatus/icon?job=optaplanner["Build Status", link="https://jenkins-kieci.rhcloud.com/job/optaplanner"]
 
-= Developing Drools and jBPM
+== Developing Drools and jBPM
 
 *If you want to build or contribute to a droolsjbpm project, https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/blob/master/README.md[read this document].*
 


### PR DESCRIPTION
"ERROR: README.adoc: line 3: only book doctypes can contain level 0 sections"