### PR TITLE
Added OK button to Constraint match dialog

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/ConstraintMatchesDialog.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/common/swingui/ConstraintMatchesDialog.java
@@ -57,8 +57,20 @@ public class ConstraintMatchesDialog extends JDialog {
     }
 
     public void resetContentPanel() {
+        JPanel buttonPanel = new JPanel(new FlowLayout());
+        Action okAction = new AbstractAction("OK") {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                setVisible(false);
+            }
+        };
+        buttonPanel.add(new JButton(okAction));
         if (!solutionBusiness.isConstraintMatchEnabled()) {
-            setContentPane(new JLabel("Constraint matches are not supported with this ScoreDirector."));
+            JPanel unsupportedPanel = new JPanel(new BorderLayout());
+            JLabel unsupportedLabel = new JLabel("Constraint matches are not supported with this ScoreDirector.");
+            unsupportedPanel.add(unsupportedLabel, BorderLayout.CENTER);
+            unsupportedPanel.add(buttonPanel, BorderLayout.SOUTH);
+            setContentPane(unsupportedPanel);
         } else {
             final List<ConstraintMatchTotal> constraintMatchTotalList
                     = solutionBusiness.getConstraintMatchTotalList();
@@ -95,14 +107,6 @@ public class ConstraintMatchesDialog extends JDialog {
                         }
                     }
             );
-            JPanel buttonPanel = new JPanel(new FlowLayout());
-            Action okAction = new AbstractAction("OK") {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    setVisible(false);
-                }
-            };
-            buttonPanel.add(new JButton(okAction));
             bottomPanel.add(buttonPanel, BorderLayout.SOUTH);
             splitPane.setBottomComponent(bottomPanel);
             splitPane.setResizeWeight(1.0);


### PR DESCRIPTION
... when constraint matches are disabled (GNOME3 doesn't render a close button). There's no way to close the dialog when that happens, except Alt+F4, which is a bad UX.

See: http://stackoverflow.com/questions/26162178/jdialog-not-showing-minimize-close-button

![screenshot from 2015-12-16 11-46-49](https://cloud.githubusercontent.com/assets/1811716/11841225/27ed47bc-a3fc-11e5-98a5-6dbc98977353.png)
