### PR TITLE
PLANNER-356: No more getProblemFacts()

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningFactCollectionProperty.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningFactCollectionProperty.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.api.domain.solution;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Collection;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specifies that a property (or a field) on a {@link Solution} class is a {@link Collection} of planning facts.
+ */
+@Target({METHOD, FIELD})
+@Retention(RUNTIME)
+public @interface PlanningFactCollectionProperty {
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningFactCollectionProperty.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningFactCollectionProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningFactProperty.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningFactProperty.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.api.domain.solution;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specifies that a property (or a field) on a {@link Solution} class is a planning fact.
+ */
+@Target({METHOD, FIELD})
+@Retention(RUNTIME)
+public @interface PlanningFactProperty {
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningFactProperty.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/PlanningFactProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/Solution.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/Solution.java
@@ -54,18 +54,4 @@ public interface Solution<S extends Score> {
      */
     void setScore(S score);
 
-    /**
-     * Called by the {@link DroolsScoreDirector} when the {@link Solution} needs to be inserted
-     * into an empty {@link KieSession}.
-     * These facts can be used by the score rules.
-     * They don't change during planning (except through {@link ProblemFactChange} events).
-     * <p>
-     * Do not include the planning entities as problem facts:
-     * they are automatically inserted into the {@link KieSession} if and only if they are initialized.
-     * When they are initialized later, they are also automatically inserted.
-     * @return never null (although an empty collection is allowed),
-     *         all the facts of this solution except for the planning entities
-     */
-    Collection<? extends Object> getProblemFacts();
-
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/AbstractSolution.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/AbstractSolution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/AbstractSolution.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/AbstractSolution.java
@@ -28,7 +28,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -62,8 +61,8 @@ public abstract class AbstractSolution<S extends Score> implements Solution<S>, 
     }
 
     @PlanningFactCollectionProperty
-    public List<Object> getProblemFactsFromClass(Class<?> instanceClass) {
-        List<Object> factList = new ArrayList<>();
+    private Collection<Object> getProblemFactsFromClass(Class<?> instanceClass) {
+        Collection<Object> factList = new ArrayList<>();
         if (instanceClass.equals(AbstractSolution.class)) {
             // The field score should not be included
             return factList;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -231,6 +231,7 @@ public class SolutionDescriptor {
     private Class<? extends Annotation> extractEntityPropertyAnnotationClass(AnnotatedElement member) {
         return extractAnnotationClass(member, PlanningEntityProperty.class, PlanningEntityCollectionProperty.class);
     }
+
     private Class<? extends Annotation> extractFactPropertyAnnotationClass(AnnotatedElement member) {
         return extractAnnotationClass(member, PlanningFactProperty.class, PlanningFactCollectionProperty.class);
     }
@@ -494,26 +495,15 @@ public class SolutionDescriptor {
 
     public Collection<Object> getAllFacts(Solution solution) {
         Collection<Object> facts = new ArrayList<>();
-        for (MemberAccessor factMemberAccessor : factPropertyAccessorMap.values()) {
-            Object fact = extract(factMemberAccessor, solution);
-            if (fact != null) {
-                facts.add(fact);
+        // will add both entities and facts
+        Arrays.asList(entityPropertyAccessorMap, factPropertyAccessorMap).forEach(map -> map.forEach((key, value) -> {
+            Object object = extract(value, solution);
+            if (object != null) {
+                facts.add(object);
             }
-        }
-        for (MemberAccessor factCollectionMemberAccessor : factCollectionPropertyAccessorMap.values()) {
-            Collection<Object> factCollection = extractCollection(factCollectionMemberAccessor, solution, true);
-            facts.addAll(factCollection);
-        }
-        for (MemberAccessor entityMemberAccessor : entityPropertyAccessorMap.values()) {
-            Object entity = extract(entityMemberAccessor, solution);
-            if (entity != null) {
-                facts.add(entity);
-            }
-        }
-        for (MemberAccessor entityCollectionMemberAccessor : entityCollectionPropertyAccessorMap.values()) {
-            Collection<Object> entityCollection = extractCollection(entityCollectionMemberAccessor, solution);
-            facts.addAll(entityCollection);
-        }
+        }));
+        Arrays.asList(entityCollectionPropertyAccessorMap, factCollectionPropertyAccessorMap).forEach(map ->
+                map.forEach((key, value) -> facts.addAll(extractCollection(value, solution))));
         return facts;
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -194,25 +194,21 @@ public class SolutionDescriptor {
         }
     }
 
-    private boolean processEntityPropertyAnnotation(DescriptorPolicy descriptorPolicy, Field field) {
+    private void processEntityPropertyAnnotation(DescriptorPolicy descriptorPolicy, Field field) {
         Class<? extends Annotation> entityPropertyAnnotationClass = extractEntityPropertyAnnotationClass(field);
         if (entityPropertyAnnotationClass != null) {
             MemberAccessor memberAccessor = new FieldMemberAccessor(field);
             registerEntityPropertyAccessor(entityPropertyAnnotationClass, memberAccessor);
-            return false;
         }
-        return true;
     }
 
-    private boolean processEntityPropertyAnnotation(DescriptorPolicy descriptorPolicy, Method method) {
+    private void processEntityPropertyAnnotation(DescriptorPolicy descriptorPolicy, Method method) {
         Class<? extends Annotation> entityPropertyAnnotationClass = extractEntityPropertyAnnotationClass(method);
         if (entityPropertyAnnotationClass != null) {
             ReflectionHelper.assertGetterMethod(method, entityPropertyAnnotationClass);
             MemberAccessor memberAccessor = new BeanPropertyMemberAccessor(method);
             registerEntityPropertyAccessor(entityPropertyAnnotationClass, memberAccessor);
-            return false;
         }
-        return true;
     }
 
     private void processFactPropertyAnnotation(DescriptorPolicy descriptorPolicy, Field field) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/domain/CheapTimeSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/domain/CheapTimeSolution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/domain/CheapTimeSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/domain/CheapTimeSolution.java
@@ -16,13 +16,10 @@
 
 package org.optaplanner.examples.cheaptime.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
@@ -31,6 +28,9 @@ import org.optaplanner.core.impl.score.buildin.hardmediumsoftlong.HardMediumSoft
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
+import java.util.List;
+
+// FIXME originally had itself as a fact
 @PlanningSolution
 @XStreamAlias("CtCheapTimeSolution")
 public class CheapTimeSolution extends AbstractPersistable implements Solution<HardMediumSoftLongScore> {
@@ -39,13 +39,19 @@ public class CheapTimeSolution extends AbstractPersistable implements Solution<H
     private int globalPeriodRangeFrom; // Inclusive
     private int globalPeriodRangeTo; // Exclusive
 
+    @PlanningFactCollectionProperty
     private List<Resource> resourceList;
     @ValueRangeProvider(id = "machineRange")
+    @PlanningFactCollectionProperty
     private List<Machine> machineList;
+    @PlanningFactCollectionProperty
     private List<MachineCapacity> machineCapacityList;
+    @PlanningFactCollectionProperty
     private List<Task> taskList;
+    @PlanningFactCollectionProperty
     private List<TaskRequirement> taskRequirementList;
     // Order is equal to global periodRange so int period can be used for the index
+    @PlanningFactCollectionProperty
     private List<PeriodPowerPrice> periodPowerPriceList;
 
     @PlanningEntityCollectionProperty
@@ -145,19 +151,5 @@ public class CheapTimeSolution extends AbstractPersistable implements Solution<H
     // ************************************************************************
     // Complex methods
     // ************************************************************************
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(resourceList);
-        facts.addAll(machineList);
-        facts.addAll(machineCapacityList);
-        facts.addAll(taskList);
-        facts.addAll(taskRequirementList);
-        facts.addAll(periodPowerPriceList);
-        facts.add(this);
-        // Do not add the planning entity's (taskAssignmentList) because that will be done automatically
-        return facts;
-    }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/domain/CheapTimeSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cheaptime/domain/CheapTimeSolution.java
@@ -146,6 +146,7 @@ public class CheapTimeSolution extends AbstractPersistable implements Solution<H
     // Complex methods
     // ************************************************************************
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.addAll(resourceList);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/domain/CloudBalance.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/domain/CloudBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/domain/CloudBalance.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/domain/CloudBalance.java
@@ -16,10 +16,6 @@
 
 package org.optaplanner.examples.cloudbalancing.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
@@ -30,6 +26,10 @@ import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.core.impl.score.buildin.hardsoft.HardSoftScoreDefinition;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 @PlanningSolution
 @XStreamAlias("CloudBalance")
@@ -72,6 +72,7 @@ public class CloudBalance extends AbstractPersistable implements Solution<HardSo
     // Complex methods
     // ************************************************************************
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.addAll(computerList);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/domain/CloudBalance.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/cloudbalancing/domain/CloudBalance.java
@@ -19,6 +19,7 @@ package org.optaplanner.examples.cloudbalancing.domain;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
@@ -27,14 +28,13 @@ import org.optaplanner.core.impl.score.buildin.hardsoft.HardSoftScoreDefinition;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 @PlanningSolution
 @XStreamAlias("CloudBalance")
 public class CloudBalance extends AbstractPersistable implements Solution<HardSoftScore> {
 
+    @PlanningFactCollectionProperty
     private List<CloudComputer> computerList;
 
     private List<CloudProcess> processList;
@@ -71,13 +71,5 @@ public class CloudBalance extends AbstractPersistable implements Solution<HardSo
     // ************************************************************************
     // Complex methods
     // ************************************************************************
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(computerList);
-        // Do not add the planning entity's (processList) because that will be done automatically
-        return facts;
-    }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/CoachShuttleGatheringSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/CoachShuttleGatheringSolution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/CoachShuttleGatheringSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/CoachShuttleGatheringSolution.java
@@ -16,11 +16,6 @@
 
 package org.optaplanner.examples.coachshuttlegathering.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
@@ -32,6 +27,11 @@ import org.optaplanner.core.impl.score.buildin.hardsoftlong.HardSoftLongScoreDef
 import org.optaplanner.examples.coachshuttlegathering.domain.location.RoadLocation;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 @PlanningSolution
 @XStreamAlias("CsgCoachShuttleGatheringSolution")
@@ -118,6 +118,7 @@ public class CoachShuttleGatheringSolution extends AbstractPersistable implement
         return Collections.singletonList(hub);
     }
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.addAll(locationList);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/CoachShuttleGatheringSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/CoachShuttleGatheringSolution.java
@@ -18,9 +18,7 @@ package org.optaplanner.examples.coachshuttlegathering.domain;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
-import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
-import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.solution.Solution;
+import org.optaplanner.core.api.domain.solution.*;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.core.impl.score.buildin.hardsoftlong.HardSoftLongScoreDefinition;
@@ -29,7 +27,6 @@ import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -38,10 +35,12 @@ import java.util.List;
 public class CoachShuttleGatheringSolution extends AbstractPersistable implements Solution<HardSoftLongScore> {
 
     protected String name;
+    @PlanningFactCollectionProperty
     protected List<RoadLocation> locationList;
     protected List<Coach> coachList;
     protected List<Shuttle> shuttleList;
     protected List<BusStop> stopList;
+    @PlanningFactProperty
     protected BusHub hub;
 
     @XStreamConverter(value = XStreamScoreConverter.class, types = {HardSoftLongScoreDefinition.class})
@@ -116,15 +115,6 @@ public class CoachShuttleGatheringSolution extends AbstractPersistable implement
     @ValueRangeProvider(id = "hubRange")
     public List<BusHub> getHubRange() {
         return Collections.singletonList(hub);
-    }
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(locationList);
-        facts.add(hub);
-        // Do not add the planning entities (coachList, shuttleList, busStopList) because that will be done automatically
-        return facts;
     }
 
     public List<Bus> getBusList() {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
@@ -16,10 +16,6 @@
 
 package org.optaplanner.examples.curriculumcourse.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
@@ -31,6 +27,10 @@ import org.optaplanner.core.impl.score.buildin.hardsoft.HardSoftScoreDefinition;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.examples.curriculumcourse.domain.solver.CourseConflict;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 @PlanningSolution
 @XStreamAlias("CourseSchedule")
@@ -148,6 +148,7 @@ public class CourseSchedule extends AbstractPersistable implements Solution<Hard
     // Complex methods
     // ************************************************************************
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.addAll(teacherList);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
@@ -19,6 +19,7 @@ package org.optaplanner.examples.curriculumcourse.domain;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
@@ -29,7 +30,6 @@ import org.optaplanner.examples.curriculumcourse.domain.solver.CourseConflict;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 @PlanningSolution
@@ -38,14 +38,22 @@ public class CourseSchedule extends AbstractPersistable implements Solution<Hard
 
     private String name;
 
+    @PlanningFactCollectionProperty
     private List<Teacher> teacherList;
+    @PlanningFactCollectionProperty
     private List<Curriculum> curriculumList;
+    @PlanningFactCollectionProperty
     private List<Course> courseList;
+    @PlanningFactCollectionProperty
     private List<Day> dayList;
+    @PlanningFactCollectionProperty
     private List<Timeslot> timeslotList;
+    @PlanningFactCollectionProperty
     private List<Period> periodList;
+    @PlanningFactCollectionProperty
     private List<Room> roomList;
 
+    @PlanningFactCollectionProperty
     private List<UnavailablePeriodPenalty> unavailablePeriodPenaltyList;
 
     private List<Lecture> lectureList;
@@ -148,22 +156,7 @@ public class CourseSchedule extends AbstractPersistable implements Solution<Hard
     // Complex methods
     // ************************************************************************
 
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(teacherList);
-        facts.addAll(curriculumList);
-        facts.addAll(courseList);
-        facts.addAll(dayList);
-        facts.addAll(timeslotList);
-        facts.addAll(periodList);
-        facts.addAll(roomList);
-        facts.addAll(unavailablePeriodPenaltyList);
-        facts.addAll(precalculateCourseConflictList());
-        // Do not add the planning entity's (lectureList) because that will be done automatically
-        return facts;
-    }
-
+    @PlanningFactCollectionProperty
     private List<CourseConflict> precalculateCourseConflictList() {
         List<CourseConflict> courseConflictList = new ArrayList<CourseConflict>();
         for (Course leftCourse : courseList) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/curriculumcourse/domain/CourseSchedule.java
@@ -157,7 +157,7 @@ public class CourseSchedule extends AbstractPersistable implements Solution<Hard
     // ************************************************************************
 
     @PlanningFactCollectionProperty
-    private List<CourseConflict> precalculateCourseConflictList() {
+    private List<CourseConflict> getCourseConflictList() {
         List<CourseConflict> courseConflictList = new ArrayList<CourseConflict>();
         for (Course leftCourse : courseList) {
             for (Course rightCourse : courseList) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/dinnerparty/domain/DinnerParty.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/dinnerparty/domain/DinnerParty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/dinnerparty/domain/DinnerParty.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/dinnerparty/domain/DinnerParty.java
@@ -16,14 +16,10 @@
 
 package org.optaplanner.examples.dinnerparty.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
@@ -32,15 +28,27 @@ import org.optaplanner.core.impl.score.buildin.simple.SimpleScoreDefinition;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
+import java.util.EnumSet;
+import java.util.List;
+
 @PlanningSolution
 @XStreamAlias("DinnerParty")
 public class DinnerParty extends AbstractPersistable implements Solution<SimpleScore> {
 
+    @PlanningFactCollectionProperty
     private List<Job> jobList;
+    @PlanningFactCollectionProperty
     private List<Guest> guestList;
+    @PlanningFactCollectionProperty
     private List<HobbyPractician> hobbyPracticianList;
+    @PlanningFactCollectionProperty
     private List<Table> tableList;
+    @PlanningFactCollectionProperty
     private List<Seat> seatList;
+    @PlanningFactCollectionProperty
+    private EnumSet<JobType> jobType = EnumSet.allOf(JobType.class);
+    @PlanningFactCollectionProperty
+    private EnumSet<Hobby> hobbyType = EnumSet.allOf(Hobby.class);
 
     private List<SeatDesignation> seatDesignationList;
 
@@ -108,19 +116,5 @@ public class DinnerParty extends AbstractPersistable implements Solution<SimpleS
     // ************************************************************************
     // Complex methods
     // ************************************************************************
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(EnumSet.allOf(JobType.class));
-        facts.addAll(jobList);
-        facts.addAll(guestList);
-        facts.addAll(EnumSet.allOf(Hobby.class));
-        facts.addAll(hobbyPracticianList);
-        facts.addAll(tableList);
-        facts.addAll(seatList);
-        // Do not add the planning entity's (seatDesignationList) because that will be done automatically
-        return facts;
-    }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/dinnerparty/domain/DinnerParty.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/dinnerparty/domain/DinnerParty.java
@@ -109,6 +109,7 @@ public class DinnerParty extends AbstractPersistable implements Solution<SimpleS
     // Complex methods
     // ************************************************************************
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.addAll(EnumSet.allOf(JobType.class));

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/dinnerparty/domain/DinnerParty.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/dinnerparty/domain/DinnerParty.java
@@ -45,15 +45,16 @@ public class DinnerParty extends AbstractPersistable implements Solution<SimpleS
     private List<Table> tableList;
     @PlanningFactCollectionProperty
     private List<Seat> seatList;
-    @PlanningFactCollectionProperty
-    private EnumSet<JobType> jobType = EnumSet.allOf(JobType.class);
-    @PlanningFactCollectionProperty
-    private EnumSet<Hobby> hobbyType = EnumSet.allOf(Hobby.class);
 
     private List<SeatDesignation> seatDesignationList;
 
     @XStreamConverter(value = XStreamScoreConverter.class, types = {SimpleScoreDefinition.class})
     private SimpleScore score;
+
+    @PlanningFactCollectionProperty
+    public EnumSet<Hobby> getHobbyType() {
+        return EnumSet.allOf(Hobby.class);
+    }
 
     public List<Job> getJobList() {
         return jobList;
@@ -61,6 +62,11 @@ public class DinnerParty extends AbstractPersistable implements Solution<SimpleS
 
     public void setJobList(List<Job> jobList) {
         this.jobList = jobList;
+    }
+
+    @PlanningFactCollectionProperty
+    public EnumSet<JobType> getJobType() {
+        return EnumSet.allOf(JobType.class);
     }
 
     public List<Guest> getGuestList() {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/Examination.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/Examination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/Examination.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/Examination.java
@@ -134,7 +134,7 @@ public class Examination extends AbstractPersistable implements Solution<HardSof
     // ************************************************************************
 
     @PlanningFactCollectionProperty
-    private List<TopicConflict> precalculateTopicConflictList() {
+    private List<TopicConflict> getTopicConflictList() {
         List<TopicConflict> topicConflictList = new ArrayList<TopicConflict>();
         for (Topic leftTopic : topicList) {
             for (Topic rightTopic : topicList) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/Examination.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/Examination.java
@@ -18,9 +18,7 @@ package org.optaplanner.examples.examination.domain;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
-import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
-import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.solution.Solution;
+import org.optaplanner.core.api.domain.solution.*;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.core.impl.score.buildin.hardsoft.HardSoftScoreDefinition;
@@ -29,21 +27,26 @@ import org.optaplanner.examples.examination.domain.solver.TopicConflict;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 @PlanningSolution()
 @XStreamAlias("Examination")
 public class Examination extends AbstractPersistable implements Solution<HardSoftScore> {
 
+    @PlanningFactProperty
     private InstitutionParametrization institutionParametrization;
 
     private List<Student> studentList;
+    @PlanningFactCollectionProperty
     private List<Topic> topicList;
+    @PlanningFactCollectionProperty
     private List<Period> periodList;
+    @PlanningFactCollectionProperty
     private List<Room> roomList;
 
+    @PlanningFactCollectionProperty
     private List<PeriodPenalty> periodPenaltyList;
+    @PlanningFactCollectionProperty
     private List<RoomPenalty> roomPenaltyList;
 
     private List<Exam> examList;
@@ -130,24 +133,7 @@ public class Examination extends AbstractPersistable implements Solution<HardSof
     // Complex methods
     // ************************************************************************
 
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.add(institutionParametrization);
-        // Student isn't used in the DRL at the moment
-        // Notice that asserting them is not a noticable performance cost, only a memory cost.
-        // facts.addAll(studentList);
-        facts.addAll(topicList);
-        facts.addAll(periodList);
-        facts.addAll(roomList);
-        facts.addAll(periodPenaltyList);
-        facts.addAll(roomPenaltyList);
-        // A faster alternative to a insertLogicalTopicConflicts rule.
-        facts.addAll(precalculateTopicConflictList());
-        // Do not add the planning entity's (examList) because that will be done automatically
-        return facts;
-    }
-
+    @PlanningFactCollectionProperty
     private List<TopicConflict> precalculateTopicConflictList() {
         List<TopicConflict> topicConflictList = new ArrayList<TopicConflict>();
         for (Topic leftTopic : topicList) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/Examination.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/examination/domain/Examination.java
@@ -16,10 +16,6 @@
 
 package org.optaplanner.examples.examination.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
@@ -32,10 +28,13 @@ import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.examples.examination.domain.solver.TopicConflict;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 @PlanningSolution()
 @XStreamAlias("Examination")
-public class Examination extends AbstractPersistable
-        implements Solution<HardSoftScore> {
+public class Examination extends AbstractPersistable implements Solution<HardSoftScore> {
 
     private InstitutionParametrization institutionParametrization;
 
@@ -131,6 +130,7 @@ public class Examination extends AbstractPersistable
     // Complex methods
     // ************************************************************************
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.add(institutionParametrization);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/domain/InvestmentSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/domain/InvestmentSolution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/domain/InvestmentSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/domain/InvestmentSolution.java
@@ -16,17 +16,9 @@
 
 package org.optaplanner.examples.investment.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
-import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
-import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.solution.Solution;
+import org.optaplanner.core.api.domain.solution.*;
 import org.optaplanner.core.api.domain.valuerange.CountableValueRange;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
@@ -36,13 +28,19 @@ import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.examples.investment.domain.util.InvestmentNumericUtil;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
+import java.util.*;
+
 @PlanningSolution
 @XStreamAlias("InvestmentSolution")
 public class InvestmentSolution extends AbstractPersistable implements Solution<HardSoftLongScore> {
 
+    @PlanningFactProperty
     private InvestmentParametrization parametrization;
+    @PlanningFactCollectionProperty
     private List<Region> regionList;
+    @PlanningFactCollectionProperty
     private List<Sector> sectorList;
+    @PlanningFactCollectionProperty
     private List<AssetClass> assetClassList;
 
     private List<AssetClassAllocation> assetClassAllocationList;
@@ -106,17 +104,6 @@ public class InvestmentSolution extends AbstractPersistable implements Solution<
     @ValueRangeProvider(id = "quantityMillisRange")
     public CountableValueRange<Long> getQuantityMillisRange() {
         return ValueRangeFactory.createLongValueRange(0L, InvestmentNumericUtil.MAXIMUM_QUANTITY_MILLIS + 1L);
-    }
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.add(parametrization);
-        facts.addAll(regionList);
-        facts.addAll(sectorList);
-        facts.addAll(assetClassList);
-        // Do not add the planning entity's (assetClassAllocationList) because that will be done automatically
-        return facts;
     }
 
     /**

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/domain/InvestmentSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/investment/domain/InvestmentSolution.java
@@ -108,6 +108,7 @@ public class InvestmentSolution extends AbstractPersistable implements Solution<
         return ValueRangeFactory.createLongValueRange(0L, InvestmentNumericUtil.MAXIMUM_QUANTITY_MILLIS + 1L);
     }
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.add(parametrization);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MachineReassignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MachineReassignment.java
@@ -16,10 +16,6 @@
 
 package org.optaplanner.examples.machinereassignment.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
@@ -31,6 +27,10 @@ import org.optaplanner.core.impl.score.buildin.hardsoftlong.HardSoftLongScoreDef
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.examples.machinereassignment.domain.solver.MrServiceDependency;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 @PlanningSolution
 @XStreamAlias("MachineReassignment")
@@ -145,6 +145,7 @@ public class MachineReassignment extends AbstractPersistable implements Solution
     // Complex methods
     // ************************************************************************
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.add(globalPenaltyInfo);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MachineReassignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MachineReassignment.java
@@ -152,7 +152,7 @@ public class MachineReassignment extends AbstractPersistable implements Solution
     // ************************************************************************
 
     @PlanningFactCollectionProperty
-    private List<MrServiceDependency> createServiceDependencyList() {
+    private List<MrServiceDependency> getServiceDependencyList() {
         List<MrServiceDependency> serviceDependencyList = new ArrayList<MrServiceDependency>(serviceList.size() * 5);
         for (MrService service : serviceList) {
             for (MrService toService : service.getToDependencyServiceList()) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MachineReassignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MachineReassignment.java
@@ -18,9 +18,7 @@ package org.optaplanner.examples.machinereassignment.domain;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
-import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
-import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.solution.Solution;
+import org.optaplanner.core.api.domain.solution.*;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import org.optaplanner.core.impl.score.buildin.hardsoftlong.HardSoftLongScoreDefinition;
@@ -29,21 +27,29 @@ import org.optaplanner.examples.machinereassignment.domain.solver.MrServiceDepen
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 @PlanningSolution
 @XStreamAlias("MachineReassignment")
 public class MachineReassignment extends AbstractPersistable implements Solution<HardSoftLongScore> {
 
+    @PlanningFactProperty
     private MrGlobalPenaltyInfo globalPenaltyInfo;
+    @PlanningFactCollectionProperty
     private List<MrResource> resourceList;
+    @PlanningFactCollectionProperty
     private List<MrNeighborhood> neighborhoodList;
+    @PlanningFactCollectionProperty
     private List<MrLocation> locationList;
+    @PlanningFactCollectionProperty
     private List<MrMachine> machineList;
+    @PlanningFactCollectionProperty
     private List<MrMachineCapacity> machineCapacityList;
+    @PlanningFactCollectionProperty
     private List<MrService> serviceList;
+    @PlanningFactCollectionProperty
     private List<MrProcess> processList;
+    @PlanningFactCollectionProperty
     private List<MrBalancePenalty> balancePenaltyList;
 
     private List<MrProcessAssignment> processAssignmentList;
@@ -145,23 +151,7 @@ public class MachineReassignment extends AbstractPersistable implements Solution
     // Complex methods
     // ************************************************************************
 
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.add(globalPenaltyInfo);
-        facts.addAll(resourceList);
-        facts.addAll(neighborhoodList);
-        facts.addAll(locationList);
-        facts.addAll(machineList);
-        facts.addAll(machineCapacityList);
-        facts.addAll(serviceList);
-        facts.addAll(createServiceDependencyList());
-        facts.addAll(processList);
-        facts.addAll(balancePenaltyList);
-        // Do not add the planning entity's (bedDesignationList) because that will be done automatically
-        return facts;
-    }
-
+    @PlanningFactCollectionProperty
     private List<MrServiceDependency> createServiceDependencyList() {
         List<MrServiceDependency> serviceDependencyList = new ArrayList<MrServiceDependency>(serviceList.size() * 5);
         for (MrService service : serviceList) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MachineReassignment.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/machinereassignment/domain/MachineReassignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/MeetingSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/MeetingSchedule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/MeetingSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/MeetingSchedule.java
@@ -16,32 +16,35 @@
 
 package org.optaplanner.examples.meetingscheduling.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
-import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.core.impl.score.buildin.hardmediumsoft.HardMediumSoftScoreDefinition;
-import org.optaplanner.core.impl.score.buildin.hardsoft.HardSoftScoreDefinition;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
+
+import java.util.List;
 
 @PlanningSolution
 @XStreamAlias("MsMeetingSchedule")
 public class MeetingSchedule extends AbstractPersistable implements Solution<HardMediumSoftScore> {
 
+    @PlanningFactCollectionProperty
     private List<Meeting> meetingList;
+    @PlanningFactCollectionProperty
     private List<Day> dayList;
+    @PlanningFactCollectionProperty
     private List<TimeGrain> timeGrainList;
+    @PlanningFactCollectionProperty
     private List<Room> roomList;
+    @PlanningFactCollectionProperty
     private List<Person> personList;
+    @PlanningFactCollectionProperty
     private List<Attendance> attendanceList;
 
     private List<MeetingAssignment> meetingAssignmentList;
@@ -121,18 +124,5 @@ public class MeetingSchedule extends AbstractPersistable implements Solution<Har
     // ************************************************************************
     // Complex methods
     // ************************************************************************
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(meetingList);
-        facts.addAll(dayList);
-        facts.addAll(timeGrainList);
-        facts.addAll(roomList);
-        facts.addAll(personList);
-        facts.addAll(attendanceList);
-        // Do not add the planning entity's (meetingAssignmentList) because that will be done automatically
-        return facts;
-    }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/MeetingSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/MeetingSchedule.java
@@ -122,6 +122,7 @@ public class MeetingSchedule extends AbstractPersistable implements Solution<Har
     // Complex methods
     // ************************************************************************
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.addAll(meetingList);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/NQueens.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/NQueens.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/NQueens.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/NQueens.java
@@ -19,6 +19,7 @@ package org.optaplanner.examples.nqueens.domain;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
@@ -27,8 +28,6 @@ import org.optaplanner.core.impl.score.buildin.simple.SimpleScoreDefinition;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 @PlanningSolution
@@ -37,11 +36,11 @@ public class NQueens extends AbstractPersistable implements Solution<SimpleScore
 
     private int n;
 
-    // Problem facts
+    @PlanningFactCollectionProperty
     private List<Column> columnList;
+    @PlanningFactCollectionProperty
     private List<Row> rowList;
 
-    // Planning entities
     private List<Queen> queenList;
 
     @XStreamConverter(value = XStreamScoreConverter.class, types = {SimpleScoreDefinition.class})
@@ -92,14 +91,5 @@ public class NQueens extends AbstractPersistable implements Solution<SimpleScore
     // ************************************************************************
     // Complex methods
     // ************************************************************************
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(columnList);
-        facts.addAll(rowList);
-        // Do not add the planning entity's (queenList) because that will be done automatically
-        return facts;
-    }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/NQueens.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nqueens/domain/NQueens.java
@@ -16,10 +16,6 @@
 
 package org.optaplanner.examples.nqueens.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
@@ -30,6 +26,10 @@ import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.score.buildin.simple.SimpleScoreDefinition;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 @PlanningSolution
 @XStreamAlias("NQueens")
@@ -93,6 +93,7 @@ public class NQueens extends AbstractPersistable implements Solution<SimpleScore
     // Complex methods
     // ************************************************************************
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.addAll(columnList);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/NurseRoster.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/NurseRoster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/NurseRoster.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/NurseRoster.java
@@ -18,9 +18,7 @@ package org.optaplanner.examples.nurserostering.domain;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
-import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
-import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.solution.Solution;
+import org.optaplanner.core.api.domain.solution.*;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.core.impl.score.buildin.hardsoft.HardSoftScoreDefinition;
@@ -35,8 +33,6 @@ import org.optaplanner.examples.nurserostering.domain.request.ShiftOffRequest;
 import org.optaplanner.examples.nurserostering.domain.request.ShiftOnRequest;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 @PlanningSolution
@@ -45,21 +41,37 @@ public class NurseRoster extends AbstractPersistable implements Solution<HardSof
 
     private String code;
 
+    @PlanningFactProperty
     private NurseRosterParametrization nurseRosterParametrization;
+    @PlanningFactCollectionProperty
     private List<Skill> skillList;
+    @PlanningFactCollectionProperty
     private List<ShiftType> shiftTypeList;
+    @PlanningFactCollectionProperty
     private List<ShiftTypeSkillRequirement> shiftTypeSkillRequirementList;
+    @PlanningFactCollectionProperty
     private List<Pattern> patternList;
+    @PlanningFactCollectionProperty
     private List<Contract> contractList;
+    @PlanningFactCollectionProperty
     private List<ContractLine> contractLineList;
+    @PlanningFactCollectionProperty
     private List<PatternContractLine> patternContractLineList;
+    @PlanningFactCollectionProperty
     private List<Employee> employeeList;
+    @PlanningFactCollectionProperty
     private List<SkillProficiency> skillProficiencyList;
+    @PlanningFactCollectionProperty
     private List<ShiftDate> shiftDateList;
+    @PlanningFactCollectionProperty
     private List<Shift> shiftList;
+    @PlanningFactCollectionProperty
     private List<DayOffRequest> dayOffRequestList;
+    @PlanningFactCollectionProperty
     private List<DayOnRequest> dayOnRequestList;
+    @PlanningFactCollectionProperty
     private List<ShiftOffRequest> shiftOffRequestList;
+    @PlanningFactCollectionProperty
     private List<ShiftOnRequest> shiftOnRequestList;
 
     private List<ShiftAssignment> shiftAssignmentList;
@@ -224,28 +236,5 @@ public class NurseRoster extends AbstractPersistable implements Solution<HardSof
     // ************************************************************************
     // Complex methods
     // ************************************************************************
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.add(nurseRosterParametrization);
-        facts.addAll(skillList);
-        facts.addAll(shiftTypeList);
-        facts.addAll(shiftTypeSkillRequirementList);
-        facts.addAll(patternList);
-        facts.addAll(contractList);
-        facts.addAll(contractLineList);
-        facts.addAll(patternContractLineList);
-        facts.addAll(employeeList);
-        facts.addAll(skillProficiencyList);
-        facts.addAll(shiftDateList);
-        facts.addAll(shiftList);
-        facts.addAll(dayOffRequestList);
-        facts.addAll(dayOnRequestList);
-        facts.addAll(shiftOffRequestList);
-        facts.addAll(shiftOnRequestList);
-        // Do not add the planning entity's (shiftAssignmentList) because that will be done automatically
-        return facts;
-    }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/NurseRoster.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/NurseRoster.java
@@ -16,10 +16,6 @@
 
 package org.optaplanner.examples.nurserostering.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
@@ -38,6 +34,10 @@ import org.optaplanner.examples.nurserostering.domain.request.DayOnRequest;
 import org.optaplanner.examples.nurserostering.domain.request.ShiftOffRequest;
 import org.optaplanner.examples.nurserostering.domain.request.ShiftOnRequest;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 @PlanningSolution
 @XStreamAlias("NurseRoster")
@@ -225,6 +225,7 @@ public class NurseRoster extends AbstractPersistable implements Solution<HardSof
     // Complex methods
     // ************************************************************************
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.add(nurseRosterParametrization);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/PatientAdmissionSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/PatientAdmissionSchedule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/PatientAdmissionSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/PatientAdmissionSchedule.java
@@ -16,13 +16,10 @@
 
 package org.optaplanner.examples.pas.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
@@ -31,22 +28,37 @@ import org.optaplanner.core.impl.score.buildin.hardmediumsoft.HardMediumSoftScor
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
+import java.util.List;
+
 @PlanningSolution
 @XStreamAlias("PatientAdmissionSchedule")
 public class PatientAdmissionSchedule extends AbstractPersistable implements Solution<HardMediumSoftScore> {
 
+    @PlanningFactCollectionProperty
     private List<Specialism> specialismList;
+    @PlanningFactCollectionProperty
     private List<Equipment> equipmentList;
+    @PlanningFactCollectionProperty
     private List<Department> departmentList;
+    @PlanningFactCollectionProperty
     private List<DepartmentSpecialism> departmentSpecialismList;
+    @PlanningFactCollectionProperty
     private List<Room> roomList;
+    @PlanningFactCollectionProperty
     private List<RoomSpecialism> roomSpecialismList;
+    @PlanningFactCollectionProperty
     private List<RoomEquipment> roomEquipmentList;
+    @PlanningFactCollectionProperty
     private List<Bed> bedList;
+    @PlanningFactCollectionProperty
     private List<Night> nightList;
+    @PlanningFactCollectionProperty
     private List<Patient> patientList;
+    @PlanningFactCollectionProperty
     private List<AdmissionPart> admissionPartList;
+    @PlanningFactCollectionProperty
     private List<RequiredPatientEquipment> requiredPatientEquipmentList;
+    @PlanningFactCollectionProperty
     private List<PreferredPatientEquipment> preferredPatientEquipmentList;
 
     private List<BedDesignation> bedDesignationList;
@@ -179,25 +191,5 @@ public class PatientAdmissionSchedule extends AbstractPersistable implements Sol
     // ************************************************************************
     // Complex methods
     // ************************************************************************
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(specialismList);
-        facts.addAll(equipmentList);
-        facts.addAll(departmentList);
-        facts.addAll(departmentSpecialismList);
-        facts.addAll(roomList);
-        facts.addAll(roomSpecialismList);
-        facts.addAll(roomEquipmentList);
-        facts.addAll(bedList);
-        facts.addAll(nightList);
-        facts.addAll(patientList);
-        facts.addAll(admissionPartList);
-        facts.addAll(requiredPatientEquipmentList);
-        facts.addAll(preferredPatientEquipmentList);
-        // Do not add the planning entity's (bedDesignationList) because that will be done automatically
-        return facts;
-    }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/PatientAdmissionSchedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/pas/domain/PatientAdmissionSchedule.java
@@ -180,6 +180,7 @@ public class PatientAdmissionSchedule extends AbstractPersistable implements Sol
     // Complex methods
     // ************************************************************************
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.addAll(specialismList);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/domain/Schedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/domain/Schedule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/domain/Schedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/domain/Schedule.java
@@ -16,13 +16,10 @@
 
 package org.optaplanner.examples.projectjobscheduling.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
@@ -31,14 +28,21 @@ import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.examples.projectjobscheduling.domain.resource.Resource;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
+import java.util.List;
+
 @PlanningSolution
 @XStreamAlias("PjsSchedule")
 public class Schedule extends AbstractPersistable implements Solution<BendableScore> {
 
+    @PlanningFactCollectionProperty
     private List<Project> projectList;
+    @PlanningFactCollectionProperty
     private List<Job> jobList;
+    @PlanningFactCollectionProperty
     private List<ExecutionMode> executionModeList;
+    @PlanningFactCollectionProperty
     private List<Resource> resourceList;
+    @PlanningFactCollectionProperty
     private List<ResourceRequirement> resourceRequirementList;
 
     private List<Allocation> allocationList;
@@ -106,17 +110,5 @@ public class Schedule extends AbstractPersistable implements Solution<BendableSc
     // ************************************************************************
     // Complex methods
     // ************************************************************************
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(projectList);
-        facts.addAll(jobList);
-        facts.addAll(executionModeList);
-        facts.addAll(resourceList);
-        facts.addAll(resourceRequirementList);
-        // Do not add the planning entity's (allocationList) because that will be done automatically
-        return facts;
-    }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/domain/Schedule.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/projectjobscheduling/domain/Schedule.java
@@ -107,6 +107,7 @@ public class Schedule extends AbstractPersistable implements Solution<BendableSc
     // Complex methods
     // ************************************************************************
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.addAll(projectList);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/TaskAssigningSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/taskassigning/domain/TaskAssigningSolution.java
@@ -16,13 +16,10 @@
 
 package org.optaplanner.examples.taskassigning.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
@@ -31,13 +28,19 @@ import org.optaplanner.core.impl.score.buildin.hardsoft.HardSoftScoreDefinition;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
+import java.util.List;
+
 @PlanningSolution
 @XStreamAlias("TaTaskAssigningSolution")
 public class TaskAssigningSolution extends AbstractPersistable implements Solution<HardSoftScore> {
 
+    @PlanningFactCollectionProperty
     private List<Skill> skillList;
+    @PlanningFactCollectionProperty
     private List<Employee> employeeList;
+    @PlanningFactCollectionProperty
     private List<TaskType> taskTypeList;
+    @PlanningFactCollectionProperty
     private List<Customer> customerList;
 
     private List<Task> taskList;
@@ -96,20 +99,6 @@ public class TaskAssigningSolution extends AbstractPersistable implements Soluti
     @Override
     public void setScore(HardSoftScore score) {
         this.score = score;
-    }
-
-    // ************************************************************************
-    // Complex methods
-    // ************************************************************************
-
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(skillList);
-        facts.addAll(employeeList);
-        facts.addAll(taskTypeList);
-        facts.addAll(customerList);
-        // Do not add the planning entity's (taskList) because that will be done automatically
-        return facts;
     }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/domain/TennisSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/domain/TennisSolution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/domain/TennisSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tennis/domain/TennisSolution.java
@@ -16,24 +16,26 @@
 
 package org.optaplanner.examples.tennis.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.hardmediumsoft.HardMediumSoftScore;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 
+import java.util.List;
+
 @PlanningSolution
 @XStreamAlias("TennisSolution")
 public class TennisSolution extends AbstractPersistable implements Solution<HardMediumSoftScore> {
 
+    @PlanningFactCollectionProperty
     private List<Team> teamList;
+    @PlanningFactCollectionProperty
     private List<Day> dayList;
+    @PlanningFactCollectionProperty
     private List<UnavailabilityPenalty> unavailabilityPenaltyList;
 
     private List<TeamAssignment> teamAssignmentList;
@@ -80,16 +82,6 @@ public class TennisSolution extends AbstractPersistable implements Solution<Hard
 
     public void setScore(HardMediumSoftScore score) {
         this.score = score;
-    }
-
-    @Override
-    public Collection<?> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(teamList);
-        facts.addAll(dayList);
-        facts.addAll(unavailabilityPenaltyList);
-        // Do not add the planning entity's (teamAssignmentList) because that will be done automatically
-        return facts;
     }
 
 }

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/domain/TravelingTournament.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/domain/TravelingTournament.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/domain/TravelingTournament.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/domain/TravelingTournament.java
@@ -16,11 +16,6 @@
 
 package org.optaplanner.examples.travelingtournament.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -32,6 +27,11 @@ import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.core.impl.score.buildin.hardsoft.HardSoftScoreDefinition;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
 
 @PlanningSolution
 @XStreamAlias("TravelingTournament")
@@ -87,6 +87,7 @@ public class TravelingTournament extends AbstractPersistable implements Solution
         return teamList.size();
     }
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.addAll(dayList);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/domain/TravelingTournament.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/travelingtournament/domain/TravelingTournament.java
@@ -20,6 +20,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
@@ -28,8 +29,6 @@ import org.optaplanner.core.impl.score.buildin.hardsoft.HardSoftScoreDefinition;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -37,7 +36,9 @@ import java.util.List;
 @XStreamAlias("TravelingTournament")
 public class TravelingTournament extends AbstractPersistable implements Solution<HardSoftScore> {
 
+    @PlanningFactCollectionProperty
     private List<Day> dayList;
+    @PlanningFactCollectionProperty
     private List<Team> teamList;
 
     private List<Match> matchList;
@@ -85,15 +86,6 @@ public class TravelingTournament extends AbstractPersistable implements Solution
 
     public int getN() {
         return teamList.size();
-    }
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(dayList);
-        facts.addAll(teamList);
-        // Do not add the planning entity's (matchList) because that will be done automatically
-        return facts;
     }
 
     public boolean equals(Object o) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/TspSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/TspSolution.java
@@ -18,9 +18,7 @@ package org.optaplanner.examples.tsp.domain;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
-import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
-import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.solution.Solution;
+import org.optaplanner.core.api.domain.solution.*;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
 import org.optaplanner.core.impl.score.buildin.simplelong.SimpleLongScoreDefinition;
@@ -30,8 +28,6 @@ import org.optaplanner.examples.tsp.domain.location.Location;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -42,7 +38,9 @@ public class TspSolution extends AbstractPersistable implements Solution<SimpleL
     private String name;
     protected DistanceType distanceType;
     protected String distanceUnitOfMeasurement;
+    @PlanningFactCollectionProperty
     private List<Location> locationList;
+    @PlanningFactProperty
     private Domicile domicile;
 
     private List<Visit> visitList;
@@ -115,15 +113,6 @@ public class TspSolution extends AbstractPersistable implements Solution<SimpleL
     @ValueRangeProvider(id = "domicileRange")
     public List<Domicile> getDomicileRange() {
         return Collections.singletonList(domicile);
-    }
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(locationList);
-        facts.add(domicile);
-        // Do not add the planning entity's (visitList) because that will be done automatically
-        return facts;
     }
 
     public String getDistanceString(NumberFormat numberFormat) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/TspSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/TspSolution.java
@@ -16,12 +16,6 @@
 
 package org.optaplanner.examples.tsp.domain;
 
-import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
@@ -31,9 +25,15 @@ import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.simplelong.SimpleLongScore;
 import org.optaplanner.core.impl.score.buildin.simplelong.SimpleLongScoreDefinition;
 import org.optaplanner.examples.common.domain.AbstractPersistable;
-import org.optaplanner.examples.tsp.domain.location.Location;
 import org.optaplanner.examples.tsp.domain.location.DistanceType;
+import org.optaplanner.examples.tsp.domain.location.Location;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
+
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 @PlanningSolution
 @XStreamAlias("TspSolution")
@@ -117,6 +117,7 @@ public class TspSolution extends AbstractPersistable implements Solution<SimpleL
         return Collections.singletonList(domicile);
     }
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.addAll(locationList);

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/TspSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/tsp/domain/TspSolution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/VehicleRoutingSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/VehicleRoutingSolution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/VehicleRoutingSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/VehicleRoutingSolution.java
@@ -20,6 +20,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import com.thoughtworks.xstream.annotations.XStreamInclude;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningFactCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
@@ -32,8 +33,6 @@ import org.optaplanner.examples.vehiclerouting.domain.timewindowed.TimeWindowedV
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
 
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 @PlanningSolution
@@ -46,7 +45,9 @@ public class VehicleRoutingSolution extends AbstractPersistable implements Solut
     protected String name;
     protected DistanceType distanceType;
     protected String distanceUnitOfMeasurement;
+    @PlanningFactCollectionProperty
     protected List<Location> locationList;
+    @PlanningFactCollectionProperty
     protected List<Depot> depotList;
     protected List<Vehicle> vehicleList;
 
@@ -126,15 +127,6 @@ public class VehicleRoutingSolution extends AbstractPersistable implements Solut
     // ************************************************************************
     // Complex methods
     // ************************************************************************
-
-    @Override
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(locationList);
-        facts.addAll(depotList);
-        // Do not add the planning entities (vehicleList, customerList) because that will be done automatically
-        return facts;
-    }
 
     public String getDistanceString(NumberFormat numberFormat) {
         if (score == null) {

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/VehicleRoutingSolution.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/domain/VehicleRoutingSolution.java
@@ -16,11 +16,6 @@
 
 package org.optaplanner.examples.vehiclerouting.domain;
 
-import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import com.thoughtworks.xstream.annotations.XStreamInclude;
@@ -35,6 +30,11 @@ import org.optaplanner.examples.vehiclerouting.domain.location.DistanceType;
 import org.optaplanner.examples.vehiclerouting.domain.location.Location;
 import org.optaplanner.examples.vehiclerouting.domain.timewindowed.TimeWindowedVehicleRoutingSolution;
 import org.optaplanner.persistence.xstream.impl.score.XStreamScoreConverter;
+
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 @PlanningSolution
 @XStreamAlias("VrpVehicleRoutingSolution")
@@ -127,6 +127,7 @@ public class VehicleRoutingSolution extends AbstractPersistable implements Solut
     // Complex methods
     // ************************************************************************
 
+    @Override
     public Collection<? extends Object> getProblemFacts() {
         List<Object> facts = new ArrayList<Object>();
         facts.addAll(locationList);


### PR DESCRIPTION
This is a proof of concept, DO NOT MERGE YET.

What I did:

- The method ```getProblemFacts()``` is gone. It is ignored if present on a ```Solution```.
- Instead, we have two new annotations in the public API, ```PlanningFactProperty``` and ```PlanningFactCollectionProperty```.
- These annotations have the exact same behavior as the equivalent entity property annotations. This is because they share most of the code...
- ... and in order to achieve that, I have done a little refactoring of ```SolutionDescriptor```. It now uses some Java 8 in places, specifically streams and lambdas, and reuses as many code paths as possible.
- The refactor did not touch places it didn't need to. As a result, the class is now mixing some imperative-style methods with some more functional-style ones.

What I need to do:

- Write some tests for the new behavior.
- Fix anything that comes out of code review.
- Add a note to migration guide.
- Squash all of this into one commit, since my "iterative" development doesn't look good here. :-)