### PR TITLE
webexamples: run tests on WildFly 10.0.0.Final (instead of 9.0.1.Final)

### DIFF
--- a/optaplanner-webexamples/pom.xml
+++ b/optaplanner-webexamples/pom.xml
@@ -24,7 +24,7 @@
   <properties>
     <!-- Overwrite ip-bom's jboss-logging version of EAP 6.4 to allow Arquillian test to work on WildFly 9 -->
     <version.org.jboss.logging.jboss-logging>3.2.1.Final</version.org.jboss.logging.jboss-logging>
-    <version.org.wildfly>9.0.1.Final</version.org.wildfly>
+    <version.org.wildfly>10.0.0.Final</version.org.wildfly>
     <version.org.wildfly.arquillian.container>1.0.0.Final</version.org.wildfly.arquillian.container>
   </properties>
   <build>
@@ -64,7 +64,7 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Overwrite ip-bom's jboss-logging version of EAP 6.4 to allow Arquillian test to work on WildFly 9 -->
+      <!-- Overwrite ip-bom's jboss-logging version of EAP 6.4 to allow Arquillian test to work on WildFly 10 -->
       <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>


### PR DESCRIPTION
 * aligns with the overall KIE platform which uses (or will use)
   WildFly 10 by default