### PR TITLE
PLANNER-554: Revert list size threshold to 16

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/SmallScalingOrderedSet.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/variable/listener/support/SmallScalingOrderedSet.java
@@ -33,7 +33,7 @@ import java.util.Set;
  */
 public final class SmallScalingOrderedSet<E> implements Set<E> {
 
-    protected static final int LIST_SIZE_THRESHOLD = 128;
+    protected static final int LIST_SIZE_THRESHOLD = 16;
 
     private boolean belowThreshold;
     private List<E> list;


### PR DESCRIPTION
This change reverts performance loss of chain move selectors in some
cases.