### PR TITLE
Test case illustrating the issue with cartesian product move in vehicle routing

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingApp.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingApp.java
@@ -30,7 +30,10 @@ public class VehicleRoutingApp extends CommonApp<VehicleRoutingSolution> {
     public static final String SOLVER_CONFIG
             = "org/optaplanner/examples/vehiclerouting/solver/vehicleRoutingSolverConfig.xml";
 
-    public static void main(String[] args) {
+    public static final String CARTESIAN_MOVE_SOLVER_CONFIG
+            = "org/optaplanner/examples/vehiclerouting/solver/vehicleRoutingCartesianMoveSolverConfig.xml";
+
+    public static void main() {
         prepareSwingEnvironment();
         new VehicleRoutingApp().init();
     }

--- a/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/solver/vehicleRoutingCartesianMoveSolverConfig.xml
+++ b/optaplanner-examples/src/main/resources/org/optaplanner/examples/vehiclerouting/solver/vehicleRoutingCartesianMoveSolverConfig.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver>
+  <!--<environmentMode>FAST_ASSERT</environmentMode>-->
+  <solutionClass>org.optaplanner.examples.vehiclerouting.domain.VehicleRoutingSolution</solutionClass>
+  <entityClass>org.optaplanner.examples.vehiclerouting.domain.Standstill</entityClass>
+  <entityClass>org.optaplanner.examples.vehiclerouting.domain.Customer</entityClass>
+  <entityClass>org.optaplanner.examples.vehiclerouting.domain.timewindowed.TimeWindowedCustomer</entityClass>
+
+  <environmentMode>FULL_ASSERT</environmentMode>
+
+  <scoreDirectorFactory>
+    <scoreDefinitionType>HARD_SOFT_LONG</scoreDefinitionType>
+    <!--<easyScoreCalculatorClass>org.optaplanner.examples.vehiclerouting.solver.score.VehicleRoutingEasyScoreCalculator</easyScoreCalculatorClass>-->
+    <!--<incrementalScoreCalculatorClass>org.optaplanner.examples.vehiclerouting.solver.score.VehicleRoutingIncrementalScoreCalculator</incrementalScoreCalculatorClass>-->
+    <scoreDrl>org/optaplanner/examples/vehiclerouting/solver/vehicleRoutingScoreRules.drl</scoreDrl>
+    <!--<assertionScoreDirectorFactory>-->
+      <!--<easyScoreCalculatorClass>org.optaplanner.examples.vehiclerouting.solver.score.VehicleRoutingEasyScoreCalculator</easyScoreCalculatorClass>-->
+    <!--</assertionScoreDirectorFactory>-->
+    <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
+  </scoreDirectorFactory>
+
+  <termination>
+    <minutesSpentLimit>5</minutesSpentLimit>
+  </termination>
+  <constructionHeuristic>
+    <constructionHeuristicType>FIRST_FIT_DECREASING</constructionHeuristicType>
+  </constructionHeuristic>
+  <localSearch>
+    <unionMoveSelector>
+      <changeMoveSelector/>
+      <swapMoveSelector/>
+      <subChainChangeMoveSelector>
+        <selectReversingMoveToo>true</selectReversingMoveToo>
+      </subChainChangeMoveSelector>
+      <subChainSwapMoveSelector>
+        <selectReversingMoveToo>true</selectReversingMoveToo>
+      </subChainSwapMoveSelector>
+
+      <cartesianProductMoveSelector>
+        <subChainChangeMoveSelector>
+          <selectReversingMoveToo>false</selectReversingMoveToo>
+        </subChainChangeMoveSelector>
+        <subChainChangeMoveSelector>
+          <selectReversingMoveToo>false</selectReversingMoveToo>
+        </subChainChangeMoveSelector>
+        <fixedProbabilityWeight>1.5</fixedProbabilityWeight>
+      </cartesianProductMoveSelector>
+    </unionMoveSelector>
+    <acceptor>
+      <lateAcceptanceSize>200</lateAcceptanceSize>
+    </acceptor>
+    <forager>
+      <acceptedCountLimit>1</acceptedCountLimit>
+    </forager>
+  </localSearch>
+</solver>

--- a/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingCartesianMovePerformanceTest.java
+++ b/optaplanner-examples/src/test/java/org/optaplanner/examples/vehiclerouting/app/VehicleRoutingCartesianMovePerformanceTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.examples.vehiclerouting.app;
+
+import org.junit.Test;
+import org.optaplanner.core.config.solver.EnvironmentMode;
+import org.optaplanner.examples.common.app.SolverPerformanceTest;
+import org.optaplanner.examples.common.persistence.SolutionDao;
+import org.optaplanner.examples.vehiclerouting.persistence.VehicleRoutingDao;
+
+import java.io.File;
+
+public class VehicleRoutingCartesianMovePerformanceTest extends SolverPerformanceTest {
+
+    @Override
+    protected String createSolverConfigResource() {
+        return VehicleRoutingApp.CARTESIAN_MOVE_SOLVER_CONFIG;
+    }
+
+    @Override
+    protected SolutionDao createSolutionDao() {
+        return new VehicleRoutingDao();
+    }
+
+    // ************************************************************************
+    // Tests
+    // ************************************************************************
+
+    @Test(timeout = 600000)
+    public void solveModel_cvrp_32customers() {
+        File unsolvedDataFile = new File("data/vehiclerouting/unsolved/cvrp-32customers.xml");
+        runSpeedTest(unsolvedDataFile, "0hard/-750000soft");
+    }
+
+    @Test(timeout = 600000)
+    public void solveModel_cvrp_32customersFastAssert() {
+        File unsolvedDataFile = new File("data/vehiclerouting/unsolved/cvrp-32customers.xml");
+        runSpeedTest(unsolvedDataFile, "0hard/-770000soft", EnvironmentMode.FAST_ASSERT);
+    }
+
+    @Test(timeout = 600000)
+    public void solveModel_cvrptw_100customers_A() {
+        File unsolvedDataFile = new File("data/vehiclerouting/unsolved/cvrptw-100customers-A.xml");
+        runSpeedTest(unsolvedDataFile, "0hard/-1869903soft");
+    }
+
+    @Test(timeout = 600000)
+    public void solveModel_cvrptw_100customers_AFastAssert() {
+        File unsolvedDataFile = new File("data/vehiclerouting/unsolved/cvrptw-100customers-A.xml");
+        runSpeedTest(unsolvedDataFile, "0hard/-1877466soft", EnvironmentMode.FAST_ASSERT);
+    }
+
+}


### PR DESCRIPTION
In reference to the discussion on [Stackoverflow](http://stackoverflow.com/questions/37611053/optaplanner-vehicle-routing-course-grained-moves), I created this PR with a test case that shows the problem with cartesianProductMoveSelector.