### PR TITLE
PLANNER-580: Make org.optaplanner.core.api.score.Score class hierarchy JavaScript-compile friendly

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/blueprint/SolverBenchmarkBluePrintType.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/blueprint/SolverBenchmarkBluePrintType.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicPhaseConfig;
 import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicType;
+import org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicTypeHelper;
 import org.optaplanner.core.config.localsearch.LocalSearchPhaseConfig;
 import org.optaplanner.core.config.localsearch.LocalSearchType;
 import org.optaplanner.core.config.phase.PhaseConfig;
@@ -61,7 +62,7 @@ public enum SolverBenchmarkBluePrintType {
     }
 
     private List<SolverBenchmarkConfig> buildEveryConstructionHeuristicType() {
-        ConstructionHeuristicType[] chTypes = ConstructionHeuristicType.getBluePrintTypes();
+        ConstructionHeuristicType[] chTypes = ConstructionHeuristicTypeHelper.getBluePrintTypes();
         List<SolverBenchmarkConfig> solverBenchmarkConfigList = new ArrayList<>(chTypes.length);
         for (ConstructionHeuristicType chType : chTypes) {
             solverBenchmarkConfigList.add(buildSolverBenchmarkConfig(chType, null));
@@ -79,7 +80,7 @@ public enum SolverBenchmarkBluePrintType {
     }
 
     private List<SolverBenchmarkConfig> buildEveryConstructionHeuristicTypeWithEveryLocalSearchType() {
-        ConstructionHeuristicType[] chTypes = ConstructionHeuristicType.getBluePrintTypes();
+        ConstructionHeuristicType[] chTypes = ConstructionHeuristicTypeHelper.getBluePrintTypes();
         LocalSearchType[] lsTypes = LocalSearchType.getBluePrintTypes();
         List<SolverBenchmarkConfig> solverBenchmarkConfigList = new ArrayList<>(
                 chTypes.length * lsTypes.length);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicPhaseConfig.java
@@ -113,12 +113,12 @@ public class ConstructionHeuristicPhaseConfig extends PhaseConfig<ConstructionHe
         ConstructionHeuristicType constructionHeuristicType_ = defaultIfNull(
                 constructionHeuristicType, ConstructionHeuristicType.ALLOCATE_ENTITY_FROM_QUEUE);
         phaseConfigPolicy.setEntitySorterManner(entitySorterManner != null ? entitySorterManner
-                : constructionHeuristicType_.getDefaultEntitySorterManner());
+                : ConstructionHeuristicTypeHelper.getDefaultEntitySorterManner(constructionHeuristicType_));
         phaseConfigPolicy.setValueSorterManner(valueSorterManner != null ? valueSorterManner
-                : constructionHeuristicType_.getDefaultValueSorterManner());
+                : ConstructionHeuristicTypeHelper.getDefaultValueSorterManner(constructionHeuristicType_));
         EntityPlacerConfig entityPlacerConfig;
         if (ConfigUtils.isEmptyCollection(entityPlacerConfigList)) {
-            entityPlacerConfig = constructionHeuristicType_.newEntityPlacerConfig();
+            entityPlacerConfig = ConstructionHeuristicTypeHelper.newEntityPlacerConfig(constructionHeuristicType_);
         } else if (entityPlacerConfigList.size() == 1) {
             entityPlacerConfig = entityPlacerConfigList.get(0);
             if (constructionHeuristicType != null) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicType.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicType.java
@@ -16,13 +16,6 @@
 
 package org.optaplanner.core.config.constructionheuristic;
 
-import org.optaplanner.core.config.constructionheuristic.placer.EntityPlacerConfig;
-import org.optaplanner.core.config.constructionheuristic.placer.PooledEntityPlacerConfig;
-import org.optaplanner.core.config.constructionheuristic.placer.QueuedEntityPlacerConfig;
-import org.optaplanner.core.config.constructionheuristic.placer.QueuedValuePlacerConfig;
-import org.optaplanner.core.config.heuristic.selector.entity.EntitySorterManner;
-import org.optaplanner.core.config.heuristic.selector.value.ValueSorterManner;
-
 public enum ConstructionHeuristicType {
     /**
      * A specific form of {@link #ALLOCATE_ENTITY_FROM_QUEUE}.
@@ -70,81 +63,4 @@ public enum ConstructionHeuristicType {
      * Repeat until all entities are assigned.
      */
     ALLOCATE_FROM_POOL;
-
-    public EntitySorterManner getDefaultEntitySorterManner() {
-        switch (this) {
-            case FIRST_FIT:
-            case WEAKEST_FIT:
-            case STRONGEST_FIT:
-                return EntitySorterManner.NONE;
-            case FIRST_FIT_DECREASING:
-            case WEAKEST_FIT_DECREASING:
-            case STRONGEST_FIT_DECREASING:
-                return EntitySorterManner.DECREASING_DIFFICULTY;
-            case ALLOCATE_ENTITY_FROM_QUEUE:
-            case ALLOCATE_TO_VALUE_FROM_QUEUE:
-            case CHEAPEST_INSERTION:
-            case ALLOCATE_FROM_POOL:
-                return EntitySorterManner.DECREASING_DIFFICULTY_IF_AVAILABLE;
-            default:
-                throw new IllegalStateException("The constructionHeuristicType (" + this + ") is not implemented.");
-        }
-    }
-
-    public ValueSorterManner getDefaultValueSorterManner() {
-        switch (this) {
-            case FIRST_FIT:
-            case FIRST_FIT_DECREASING:
-                return ValueSorterManner.NONE;
-            case WEAKEST_FIT:
-            case WEAKEST_FIT_DECREASING:
-                return ValueSorterManner.INCREASING_STRENGTH;
-            case STRONGEST_FIT:
-            case STRONGEST_FIT_DECREASING:
-                return ValueSorterManner.DECREASING_STRENGTH;
-            case ALLOCATE_ENTITY_FROM_QUEUE:
-            case ALLOCATE_TO_VALUE_FROM_QUEUE:
-            case CHEAPEST_INSERTION:
-            case ALLOCATE_FROM_POOL:
-                return ValueSorterManner.INCREASING_STRENGTH_IF_AVAILABLE;
-            default:
-                throw new IllegalStateException("The constructionHeuristicType (" + this + ") is not implemented.");
-        }
-    }
-
-    public EntityPlacerConfig newEntityPlacerConfig() {
-        switch (this) {
-            case FIRST_FIT:
-            case FIRST_FIT_DECREASING:
-            case WEAKEST_FIT:
-            case WEAKEST_FIT_DECREASING:
-            case STRONGEST_FIT:
-            case STRONGEST_FIT_DECREASING:
-            case ALLOCATE_ENTITY_FROM_QUEUE:
-                return new QueuedEntityPlacerConfig();
-            case ALLOCATE_TO_VALUE_FROM_QUEUE:
-                return new QueuedValuePlacerConfig();
-            case CHEAPEST_INSERTION:
-            case ALLOCATE_FROM_POOL:
-                return new PooledEntityPlacerConfig();
-            default:
-                throw new IllegalStateException("The constructionHeuristicType (" + this + ") is not implemented.");
-        }
-    }
-
-    /**
-     * @return {@link #values()} without duplicates (abstract types that end up behaving as one of the other types).
-     */
-    public static ConstructionHeuristicType[] getBluePrintTypes() {
-        return new ConstructionHeuristicType[] {
-            FIRST_FIT,
-            FIRST_FIT_DECREASING,
-            WEAKEST_FIT,
-            WEAKEST_FIT_DECREASING,
-            STRONGEST_FIT,
-            STRONGEST_FIT_DECREASING,
-            CHEAPEST_INSERTION
-        };
-    }
-
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicTypeHelper.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/ConstructionHeuristicTypeHelper.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.config.constructionheuristic;
+
+import org.optaplanner.core.config.constructionheuristic.placer.EntityPlacerConfig;
+import org.optaplanner.core.config.constructionheuristic.placer.PooledEntityPlacerConfig;
+import org.optaplanner.core.config.constructionheuristic.placer.QueuedEntityPlacerConfig;
+import org.optaplanner.core.config.constructionheuristic.placer.QueuedValuePlacerConfig;
+import org.optaplanner.core.config.heuristic.selector.entity.EntitySorterManner;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSorterManner;
+
+import static org.optaplanner.core.config.constructionheuristic.ConstructionHeuristicType.*;
+
+public final class ConstructionHeuristicTypeHelper {
+
+    private ConstructionHeuristicTypeHelper() {
+    }
+
+    public static EntitySorterManner getDefaultEntitySorterManner(ConstructionHeuristicType constructionHeuristicType) {
+        switch (constructionHeuristicType) {
+            case FIRST_FIT:
+            case WEAKEST_FIT:
+            case STRONGEST_FIT:
+                return EntitySorterManner.NONE;
+            case FIRST_FIT_DECREASING:
+            case WEAKEST_FIT_DECREASING:
+            case STRONGEST_FIT_DECREASING:
+                return EntitySorterManner.DECREASING_DIFFICULTY;
+            case ALLOCATE_ENTITY_FROM_QUEUE:
+            case ALLOCATE_TO_VALUE_FROM_QUEUE:
+            case CHEAPEST_INSERTION:
+            case ALLOCATE_FROM_POOL:
+                return EntitySorterManner.DECREASING_DIFFICULTY_IF_AVAILABLE;
+            default:
+                throw new IllegalStateException("The constructionHeuristicType (" + constructionHeuristicType + ") is not implemented.");
+        }
+    }
+
+    public static ValueSorterManner getDefaultValueSorterManner(ConstructionHeuristicType constructionHeuristicType) {
+        switch (constructionHeuristicType) {
+            case FIRST_FIT:
+            case FIRST_FIT_DECREASING:
+                return ValueSorterManner.NONE;
+            case WEAKEST_FIT:
+            case WEAKEST_FIT_DECREASING:
+                return ValueSorterManner.INCREASING_STRENGTH;
+            case STRONGEST_FIT:
+            case STRONGEST_FIT_DECREASING:
+                return ValueSorterManner.DECREASING_STRENGTH;
+            case ALLOCATE_ENTITY_FROM_QUEUE:
+            case ALLOCATE_TO_VALUE_FROM_QUEUE:
+            case CHEAPEST_INSERTION:
+            case ALLOCATE_FROM_POOL:
+                return ValueSorterManner.INCREASING_STRENGTH_IF_AVAILABLE;
+            default:
+                throw new IllegalStateException("The constructionHeuristicType (" + constructionHeuristicType + ") is not implemented.");
+        }
+    }
+
+    public static EntityPlacerConfig newEntityPlacerConfig(ConstructionHeuristicType constructionHeuristicType) {
+        switch (constructionHeuristicType) {
+            case FIRST_FIT:
+            case FIRST_FIT_DECREASING:
+            case WEAKEST_FIT:
+            case WEAKEST_FIT_DECREASING:
+            case STRONGEST_FIT:
+            case STRONGEST_FIT_DECREASING:
+            case ALLOCATE_ENTITY_FROM_QUEUE:
+                return new QueuedEntityPlacerConfig();
+            case ALLOCATE_TO_VALUE_FROM_QUEUE:
+                return new QueuedValuePlacerConfig();
+            case CHEAPEST_INSERTION:
+            case ALLOCATE_FROM_POOL:
+                return new PooledEntityPlacerConfig();
+            default:
+                throw new IllegalStateException("The constructionHeuristicType (" + constructionHeuristicType + ") is not implemented.");
+        }
+    }
+
+    /**
+     * @return {@link ConstructionHeuristicType#values()} without duplicates (abstract types that end up behaving as one of the other types).
+     */
+    public static ConstructionHeuristicType[] getBluePrintTypes() {
+        return new ConstructionHeuristicType[] {
+                FIRST_FIT,
+                FIRST_FIT_DECREASING,
+                WEAKEST_FIT,
+                WEAKEST_FIT_DECREASING,
+                STRONGEST_FIT,
+                STRONGEST_FIT_DECREASING,
+                CHEAPEST_INSERTION
+        };
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/PooledEntityPlacerConfig.java
@@ -27,11 +27,13 @@ import org.optaplanner.core.config.heuristic.policy.HeuristicConfigPolicy;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.entity.EntitySorterMannerHelper;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSorterMannerHelper;
 import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.constructionheuristic.placer.PooledEntityPlacer;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
@@ -109,7 +111,7 @@ public class PooledEntityPlacerConfig extends EntityPlacerConfig<PooledEntityPla
         Class<?> entityClass = entityDescriptor.getEntityClass();
         entitySelectorConfig.setId(entityClass.getName());
         entitySelectorConfig.setEntityClass(entityClass);
-        if (configPolicy.getEntitySorterManner().hasSorter(entityDescriptor)) {
+        if (EntitySorterMannerHelper.hasSorter(configPolicy.getEntitySorterManner(), entityDescriptor)) {
             entitySelectorConfig.setCacheType(SelectionCacheType.PHASE);
             entitySelectorConfig.setSelectionOrder(SelectionOrder.SORTED);
             entitySelectorConfig.setSorterManner(configPolicy.getEntitySorterManner());
@@ -125,7 +127,7 @@ public class PooledEntityPlacerConfig extends EntityPlacerConfig<PooledEntityPla
         changeMoveSelectorConfig.setEntitySelectorConfig(changeEntitySelectorConfig);
         ValueSelectorConfig changeValueSelectorConfig = new ValueSelectorConfig();
         changeValueSelectorConfig.setVariableName(variableDescriptor.getVariableName());
-        if (configPolicy.getValueSorterManner().hasSorter(variableDescriptor)) {
+        if (ValueSorterMannerHelper.hasSorter(configPolicy.getValueSorterManner(), variableDescriptor)) {
             if (variableDescriptor.isValueRangeEntityIndependent()) {
                 changeValueSelectorConfig.setCacheType(SelectionCacheType.PHASE);
             } else {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedEntityPlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedEntityPlacerConfig.java
@@ -27,10 +27,12 @@ import org.optaplanner.core.config.heuristic.policy.HeuristicConfigPolicy;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.entity.EntitySorterMannerHelper;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSorterMannerHelper;
 import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.constructionheuristic.placer.QueuedEntityPlacer;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
@@ -113,7 +115,7 @@ public class QueuedEntityPlacerConfig extends EntityPlacerConfig<QueuedEntityPla
             Class<?> entityClass = entityDescriptor.getEntityClass();
             entitySelectorConfig_.setId(entityClass.getName());
             entitySelectorConfig_.setEntityClass(entityClass);
-            if (configPolicy.getEntitySorterManner().hasSorter(entityDescriptor)) {
+            if (EntitySorterMannerHelper.hasSorter(configPolicy.getEntitySorterManner(), entityDescriptor)) {
                 entitySelectorConfig_.setCacheType(SelectionCacheType.PHASE);
                 entitySelectorConfig_.setSelectionOrder(SelectionOrder.SORTED);
                 entitySelectorConfig_.setSorterManner(configPolicy.getEntitySorterManner());
@@ -139,7 +141,7 @@ public class QueuedEntityPlacerConfig extends EntityPlacerConfig<QueuedEntityPla
         changeMoveSelectorConfig.setEntitySelectorConfig(changeEntitySelectorConfig);
         ValueSelectorConfig changeValueSelectorConfig = new ValueSelectorConfig();
         changeValueSelectorConfig.setVariableName(variableDescriptor.getVariableName());
-        if (configPolicy.getValueSorterManner().hasSorter(variableDescriptor)) {
+        if (ValueSorterMannerHelper.hasSorter(configPolicy.getValueSorterManner(), variableDescriptor)) {
             if (variableDescriptor.isValueRangeEntityIndependent()) {
                 changeValueSelectorConfig.setCacheType(SelectionCacheType.PHASE);
             } else {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedValuePlacerConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/constructionheuristic/placer/QueuedValuePlacerConfig.java
@@ -26,11 +26,13 @@ import org.optaplanner.core.config.heuristic.policy.HeuristicConfigPolicy;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.entity.EntitySorterMannerHelper;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSorterMannerHelper;
 import org.optaplanner.core.config.util.ConfigUtils;
 import org.optaplanner.core.impl.constructionheuristic.placer.QueuedValuePlacer;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
@@ -121,7 +123,7 @@ public class QueuedValuePlacerConfig extends EntityPlacerConfig<QueuedValuePlace
             GenuineVariableDescriptor variableDescriptor = deduceVariableDescriptor(entityDescriptor, null);
             valueSelectorConfig_.setId(entityClass.getName() + "." + variableDescriptor.getVariableName());
             valueSelectorConfig_.setVariableName(variableDescriptor.getVariableName());
-            if (configPolicy.getValueSorterManner().hasSorter(variableDescriptor)) {
+            if (ValueSorterMannerHelper.hasSorter(configPolicy.getValueSorterManner(), variableDescriptor)) {
                 valueSelectorConfig_.setCacheType(SelectionCacheType.PHASE);
                 valueSelectorConfig_.setSelectionOrder(SelectionOrder.SORTED);
                 valueSelectorConfig_.setSorterManner(configPolicy.getValueSorterManner());
@@ -145,7 +147,7 @@ public class QueuedValuePlacerConfig extends EntityPlacerConfig<QueuedValuePlace
         EntitySelectorConfig changeEntitySelectorConfig = new EntitySelectorConfig();
         EntityDescriptor entityDescriptor = variableDescriptor.getEntityDescriptor();
         changeEntitySelectorConfig.setEntityClass(entityDescriptor.getEntityClass());
-        if (configPolicy.getEntitySorterManner().hasSorter(entityDescriptor)) {
+        if (EntitySorterMannerHelper.hasSorter(configPolicy.getEntitySorterManner(), entityDescriptor)) {
             changeEntitySelectorConfig.setCacheType(SelectionCacheType.PHASE);
             changeEntitySelectorConfig.setSelectionOrder(SelectionOrder.SORTED);
             changeEntitySelectorConfig.setSorterManner(configPolicy.getEntitySorterManner());

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/exhaustivesearch/ExhaustiveSearchPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/exhaustivesearch/ExhaustiveSearchPhaseConfig.java
@@ -26,11 +26,13 @@ import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySorterManner;
+import org.optaplanner.core.config.heuristic.selector.entity.EntitySorterMannerHelper;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.composite.CartesianProductMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSorterManner;
+import org.optaplanner.core.config.heuristic.selector.value.ValueSorterMannerHelper;
 import org.optaplanner.core.config.phase.PhaseConfig;
 import org.optaplanner.core.config.solver.EnvironmentMode;
 import org.optaplanner.core.config.util.ConfigUtils;
@@ -171,7 +173,7 @@ public class ExhaustiveSearchPhaseConfig extends PhaseConfig<ExhaustiveSearchPha
             entitySelectorConfig_ = new EntitySelectorConfig();
             EntityDescriptor entityDescriptor = deduceEntityDescriptor(configPolicy.getSolutionDescriptor());
             entitySelectorConfig_.setEntityClass(entityDescriptor.getEntityClass());
-            if (configPolicy.getEntitySorterManner().hasSorter(entityDescriptor)) {
+            if (EntitySorterMannerHelper.hasSorter(configPolicy.getEntitySorterManner(), entityDescriptor)) {
                 entitySelectorConfig_.setCacheType(SelectionCacheType.PHASE);
                 entitySelectorConfig_.setSelectionOrder(SelectionOrder.SORTED);
                 entitySelectorConfig_.setSorterManner(configPolicy.getEntitySorterManner());
@@ -242,7 +244,7 @@ public class ExhaustiveSearchPhaseConfig extends PhaseConfig<ExhaustiveSearchPha
                 changeMoveSelectorConfig.setEntitySelectorConfig(changeEntitySelectorConfig);
                 ValueSelectorConfig changeValueSelectorConfig = new ValueSelectorConfig();
                 changeValueSelectorConfig.setVariableName(variableDescriptor.getVariableName());
-                if (configPolicy.getValueSorterManner().hasSorter(variableDescriptor)) {
+                if (ValueSorterMannerHelper.hasSorter(configPolicy.getValueSorterManner(), variableDescriptor)) {
                     if (variableDescriptor.isValueRangeEntityIndependent()) {
                         changeValueSelectorConfig.setCacheType(SelectionCacheType.PHASE);
                     } else {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySelectorConfig.java
@@ -427,10 +427,10 @@ public class EntitySelectorConfig extends SelectorConfig<EntitySelectorConfig> {
             SelectionSorter sorter;
             if (sorterManner != null) {
                 EntityDescriptor entityDescriptor = entitySelector.getEntityDescriptor();
-                if (!sorterManner.hasSorter(entityDescriptor)) {
+                if (!EntitySorterMannerHelper.hasSorter(sorterManner, entityDescriptor)) {
                     return entitySelector;
                 }
-                sorter = sorterManner.determineSorter(entityDescriptor);
+                sorter = EntitySorterMannerHelper.determineSorter(sorterManner, entityDescriptor);
             } else if (sorterComparatorClass != null) {
                 Comparator<Object> sorterComparator = ConfigUtils.newInstance(this,
                         "sorterComparatorClass", sorterComparatorClass);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySorterManner.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySorterManner.java
@@ -17,8 +17,6 @@
 package org.optaplanner.core.config.heuristic.selector.entity;
 
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
-import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
-import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSorter;
 
 /**
  * The manner of sorting {@link PlanningEntity} instances.
@@ -27,40 +25,4 @@ public enum EntitySorterManner {
     NONE,
     DECREASING_DIFFICULTY,
     DECREASING_DIFFICULTY_IF_AVAILABLE;
-
-    public boolean hasSorter(EntityDescriptor entityDescriptor) {
-        switch (this) {
-            case NONE:
-                return false;
-            case DECREASING_DIFFICULTY:
-                return true;
-            case DECREASING_DIFFICULTY_IF_AVAILABLE:
-                return entityDescriptor.getDecreasingDifficultySorter() != null;
-            default:
-                throw new IllegalStateException("The sorterManner ("
-                        + this + ") is not implemented.");
-        }
-    }
-
-    public SelectionSorter determineSorter(EntityDescriptor entityDescriptor) {
-        SelectionSorter sorter;
-        switch (this) {
-            case NONE:
-                throw new IllegalStateException("Impossible state: hasSorter() should have returned null.");
-            case DECREASING_DIFFICULTY:
-            case DECREASING_DIFFICULTY_IF_AVAILABLE:
-                sorter = entityDescriptor.getDecreasingDifficultySorter();
-                if (sorter == null) {
-                    throw new IllegalArgumentException("The sorterManner (" + this
-                            + ") on entity class (" + entityDescriptor.getEntityClass()
-                            + ") fails because that entity class's @" + PlanningEntity.class.getSimpleName()
-                            + " annotation does not declare any difficulty comparison.");
-                }
-                return sorter;
-            default:
-                throw new IllegalStateException("The sorterManner ("
-                        + this + ") is not implemented.");
-        }
-    }
-
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySorterMannerHelper.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/entity/EntitySorterMannerHelper.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.config.heuristic.selector.entity;
+
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
+import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSorter;
+
+public final class EntitySorterMannerHelper {
+
+    private EntitySorterMannerHelper() {
+    }
+
+    public static boolean hasSorter(EntitySorterManner entitySorterManner, EntityDescriptor entityDescriptor) {
+        switch (entitySorterManner) {
+            case NONE:
+                return false;
+            case DECREASING_DIFFICULTY:
+                return true;
+            case DECREASING_DIFFICULTY_IF_AVAILABLE:
+                return entityDescriptor.getDecreasingDifficultySorter() != null;
+            default:
+                throw new IllegalStateException("The sorterManner ("
+                        + entitySorterManner + ") is not implemented.");
+        }
+    }
+
+    public static SelectionSorter determineSorter(EntitySorterManner entitySorterManner, EntityDescriptor entityDescriptor) {
+        SelectionSorter sorter;
+        switch (entitySorterManner) {
+            case NONE:
+                throw new IllegalStateException("Impossible state: hasSorter() should have returned null.");
+            case DECREASING_DIFFICULTY:
+            case DECREASING_DIFFICULTY_IF_AVAILABLE:
+                sorter = entityDescriptor.getDecreasingDifficultySorter();
+                if (sorter == null) {
+                    throw new IllegalArgumentException("The sorterManner (" + entitySorterManner
+                            + ") on entity class (" + entityDescriptor.getEntityClass()
+                            + ") fails because that entity class's @" + PlanningEntity.class.getSimpleName()
+                            + " annotation does not declare any difficulty comparison.");
+                }
+                return sorter;
+            default:
+                throw new IllegalStateException("The sorterManner ("
+                        + entitySorterManner + ") is not implemented.");
+        }
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSelectorConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSelectorConfig.java
@@ -495,10 +495,10 @@ public class ValueSelectorConfig extends SelectorConfig<ValueSelectorConfig> {
             SelectionSorter sorter;
             if (sorterManner != null) {
                 GenuineVariableDescriptor variableDescriptor = valueSelector.getVariableDescriptor();
-                if (!sorterManner.hasSorter(variableDescriptor)) {
+                if (!ValueSorterMannerHelper.hasSorter(sorterManner, variableDescriptor)) {
                     return valueSelector;
                 }
-                sorter = sorterManner.determineSorter(variableDescriptor);
+                sorter = ValueSorterMannerHelper.determineSorter(sorterManner, variableDescriptor);
             } else if (sorterComparatorClass != null) {
                 Comparator<Object> sorterComparator = ConfigUtils.newInstance(this,
                         "sorterComparatorClass", sorterComparatorClass);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSorterManner.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSorterManner.java
@@ -17,8 +17,6 @@
 package org.optaplanner.core.config.heuristic.selector.value;
 
 import org.optaplanner.core.api.domain.variable.PlanningVariable;
-import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
-import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSorter;
 
 /**
  * The manner of sorting a values for a {@link PlanningVariable}.
@@ -29,49 +27,4 @@ public enum ValueSorterManner {
     INCREASING_STRENGTH_IF_AVAILABLE,
     DECREASING_STRENGTH,
     DECREASING_STRENGTH_IF_AVAILABLE;
-
-    public boolean hasSorter(GenuineVariableDescriptor variableDescriptor) {
-        switch (this) {
-            case NONE:
-                return false;
-            case INCREASING_STRENGTH:
-            case DECREASING_STRENGTH:
-                return true;
-            case INCREASING_STRENGTH_IF_AVAILABLE:
-                return variableDescriptor.getIncreasingStrengthSorter() != null;
-            case DECREASING_STRENGTH_IF_AVAILABLE:
-                return variableDescriptor.getDecreasingStrengthSorter() != null;
-            default:
-                throw new IllegalStateException("The sorterManner ("
-                        + this + ") is not implemented.");
-        }
-    }
-
-    public SelectionSorter determineSorter(GenuineVariableDescriptor variableDescriptor) {
-        SelectionSorter sorter;
-        switch (this) {
-            case NONE:
-                throw new IllegalStateException("Impossible state: hasSorter() should have returned null.");
-            case INCREASING_STRENGTH:
-            case INCREASING_STRENGTH_IF_AVAILABLE:
-                sorter = variableDescriptor.getIncreasingStrengthSorter();
-                break;
-            case DECREASING_STRENGTH:
-            case DECREASING_STRENGTH_IF_AVAILABLE:
-                sorter = variableDescriptor.getDecreasingStrengthSorter();
-                break;
-            default:
-                throw new IllegalStateException("The sorterManner ("
-                        + this + ") is not implemented.");
-        }
-        if (sorter == null) {
-            throw new IllegalArgumentException("The sorterManner (" + this
-                    + ") on entity class (" + variableDescriptor.getEntityDescriptor().getEntityClass()
-                    + ")'s variable (" + variableDescriptor.getVariableName()
-                    + ") fails because that variable getter's " + PlanningVariable.class.getSimpleName()
-                    + " annotation does not declare any strength comparison.");
-        }
-        return sorter;
-    }
-
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSorterMannerHelper.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/heuristic/selector/value/ValueSorterMannerHelper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.optaplanner.core.config.heuristic.selector.value;
+
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+import org.optaplanner.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
+import org.optaplanner.core.impl.heuristic.selector.common.decorator.SelectionSorter;
+
+public final class ValueSorterMannerHelper {
+
+    private ValueSorterMannerHelper() {
+    }
+
+    public static boolean hasSorter(ValueSorterManner valueSorterManner, GenuineVariableDescriptor variableDescriptor) {
+        switch (valueSorterManner) {
+            case NONE:
+                return false;
+            case INCREASING_STRENGTH:
+            case DECREASING_STRENGTH:
+                return true;
+            case INCREASING_STRENGTH_IF_AVAILABLE:
+                return variableDescriptor.getIncreasingStrengthSorter() != null;
+            case DECREASING_STRENGTH_IF_AVAILABLE:
+                return variableDescriptor.getDecreasingStrengthSorter() != null;
+            default:
+                throw new IllegalStateException("The sorterManner ("
+                        + valueSorterManner + ") is not implemented.");
+        }
+    }
+
+    public static SelectionSorter determineSorter(ValueSorterManner valueSorterManner, GenuineVariableDescriptor variableDescriptor) {
+        SelectionSorter sorter;
+        switch (valueSorterManner) {
+            case NONE:
+                throw new IllegalStateException("Impossible state: hasSorter() should have returned null.");
+            case INCREASING_STRENGTH:
+            case INCREASING_STRENGTH_IF_AVAILABLE:
+                sorter = variableDescriptor.getIncreasingStrengthSorter();
+                break;
+            case DECREASING_STRENGTH:
+            case DECREASING_STRENGTH_IF_AVAILABLE:
+                sorter = variableDescriptor.getDecreasingStrengthSorter();
+                break;
+            default:
+                throw new IllegalStateException("The sorterManner ("
+                        + valueSorterManner + ") is not implemented.");
+        }
+        if (sorter == null) {
+            throw new IllegalArgumentException("The sorterManner (" + valueSorterManner
+                    + ") on entity class (" + variableDescriptor.getEntityDescriptor().getEntityClass()
+                    + ")'s variable (" + variableDescriptor.getVariableName()
+                    + ") fails because that variable getter's " + PlanningVariable.class.getSimpleName()
+                    + " annotation does not declare any strength comparison.");
+        }
+        return sorter;
+    }
+
+}


### PR DESCRIPTION
This relates to reusing enums from `ConstructionHeuristicPhaseConfig` in the Workbench. As the enum methods introduced too many class dependencies, a split into enum & helper class is required.