### PR TITLE
persistence-jaxb: depend explicitly on JavaEE specs

### DIFF
--- a/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
@@ -54,12 +54,20 @@
     </dependency>
     <!-- XML and JSON -->
     <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
 * fix for JDK9 which does not by default includes these
 * still works on JDK8

@ge0ffrey please take a look and let me know if you have any concerns.