### PR TITLE
Review score directors, fix getContraintMatchTotals()

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/holder/AbstractScoreHolder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/holder/AbstractScoreHolder.java
@@ -31,7 +31,6 @@ import org.kie.api.runtime.rule.Match;
 import org.kie.api.runtime.rule.RuleContext;
 import org.kie.api.runtime.rule.RuleRuntime;
 import org.kie.internal.event.rule.ActivationUnMatchListener;
-import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.constraint.ConstraintMatchTotal;
 import org.optaplanner.core.api.score.constraint.bigdecimal.BigDecimalConstraintMatch;
 import org.optaplanner.core.api.score.constraint.bigdecimal.BigDecimalConstraintMatchTotal;
@@ -41,7 +40,6 @@ import org.optaplanner.core.api.score.constraint.primint.IntConstraintMatch;
 import org.optaplanner.core.api.score.constraint.primint.IntConstraintMatchTotal;
 import org.optaplanner.core.api.score.constraint.primlong.LongConstraintMatch;
 import org.optaplanner.core.api.score.constraint.primlong.LongConstraintMatchTotal;
-import org.optaplanner.core.impl.score.director.ScoreDirector;
 
 /**
  * Abstract superclass for {@link ScoreHolder}.
@@ -64,6 +62,10 @@ public abstract class AbstractScoreHolder implements ScoreHolder, Serializable {
 
     @Override
     public Collection<ConstraintMatchTotal> getConstraintMatchTotals() {
+        if (!isConstraintMatchEnabled()) {
+            throw new IllegalStateException("When constraintMatchEnabled (" + isConstraintMatchEnabled()
+                    + ") is disabled, this method should not be called.");
+        }
         return constraintMatchTotalMap.values();
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/holder/ScoreHolder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/holder/ScoreHolder.java
@@ -61,7 +61,7 @@ public interface ScoreHolder {
      * <p>
      * Should not be called directly, use {@link ScoreDirector#getConstraintMatchTotals()} instead.
      * @return never null
-     * @throws RuntimeException if {@link #isConstraintMatchEnabled()} is false
+     * @throws IllegalStateException if {@link #isConstraintMatchEnabled()} is false
      */
     Collection<ConstraintMatchTotal> getConstraintMatchTotals();
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/ScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/ScoreDirector.java
@@ -34,21 +34,21 @@ public interface ScoreDirector<Solution_> {
     /**
      * The {@link PlanningSolution} that is used to calculate the {@link Score}.
      * <p>
-     * Because a {@link Score} is best calculated incrementally (by delta's),
-     * the {@link ScoreDirector} needs to be notified when it's {@link PlanningSolution working solution} changes.
+     * Because a {@link Score} is best calculated incrementally (by deltas),
+     * the {@link ScoreDirector} needs to be notified when its {@link PlanningSolution working solution} changes.
      * <p>
-     * If the {@link PlanningSolution working solution} has been changed since {@link #calculateScore} has been called,
+     * If the {@link PlanningSolution working solution} has been changed since {@link #calculateScore} was called,
      * its {@link Score} won't be correct.
      * @return never null
      */
     Solution_ getWorkingSolution();
 
     /**
-     * The {@link PlanningSolution working solution} must never be the same instance as the {@link PlanningSolution best solution},
-     * it should be a (un)changed clone.
+     * The {@link PlanningSolution working solution} must never be the same instance as the
+     * {@link PlanningSolution best solution}, it should be a (un)changed clone.
      * <p>
      * Only call this method on a separate {@link ScoreDirector} instance,
-     * build by {@link Solver#getScoreDirectorFactory()},
+     * built by {@link Solver#getScoreDirectorFactory()},
      * not on the one used inside the {@link Solver} itself.
      * @param workingSolution never null
      */
@@ -66,6 +66,7 @@ public interface ScoreDirector<Solution_> {
     boolean isConstraintMatchEnabled();
 
     /**
+     * Explains the {@link Score} of {@link #calculateScore()}.
      * @return never null
      * @throws IllegalStateException if {@link #isConstraintMatchEnabled()} returns false
      */

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/easy/EasyScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/easy/EasyScoreDirector.java
@@ -27,6 +27,7 @@ import org.optaplanner.core.impl.score.director.ScoreDirector;
 /**
  * Easy java implementation of {@link ScoreDirector}, which recalculates the {@link Score}
  * of the {@link PlanningSolution working solution} every time. This is non-incremental calculation, which is slow.
+ * This score director implementation does not support {@link ScoreDirector#getConstraintMatchTotals()}.
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  * @see ScoreDirector
  */
@@ -54,15 +55,23 @@ public class EasyScoreDirector<Solution_>
         return score;
     }
 
+    /**
+     * Always false, {@link ConstraintMatchTotal}s are not supported by this {@link ScoreDirector} implementation.
+     * @return false
+     */
     @Override
     public boolean isConstraintMatchEnabled() {
         return false;
     }
 
+    /**
+     * {@link ConstraintMatchTotal}s are not supported by this {@link ScoreDirector} implementation.
+     * @throws IllegalStateException always
+     * @return
+     */
     @Override
     public Collection<ConstraintMatchTotal> getConstraintMatchTotals() {
-        throw new IllegalStateException("When constraintMatchEnabled (" + isConstraintMatchEnabled()
-                + ") is disabled, this method should not be called.");
+        throw new IllegalStateException("ConstraintMatchTotals are not supported by EasyScoreDirector.");
     }
 
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/holder/ScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/holder/ScoreHolderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.api.score.holder;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.optaplanner.core.api.score.Score;
+
+import static org.junit.Assert.assertNotNull;
+
+public class ScoreHolderTest {
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void illegalStateExceptionThrownWhenConstraintMatchNotEnabled() {
+        ScoreHolder scoreHolder = buildScoreHolder(false);
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("constraintMatchEnabled");
+        scoreHolder.getConstraintMatchTotals().clear();
+    }
+
+    @Test
+    public void constraintMatchTotalsNeverNull() {
+        assertNotNull(buildScoreHolder(true).getConstraintMatchTotals());
+    }
+
+    private ScoreHolder buildScoreHolder(boolean constraintMatchEnabled) {
+        return new AbstractScoreHolder(constraintMatchEnabled) {
+            private static final long serialVersionUID = 3167742145462539743L;
+
+            @Override
+            public Score<?> extractScore(int initScore) {
+                return null;
+            }
+        };
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/DroolsScoreDirectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/DroolsScoreDirectorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.score.director.drools;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.kie.api.runtime.KieSession;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.score.buildin.simple.SimpleScoreDefinition;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+public class DroolsScoreDirectorTest {
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void illegalStateExceptionThrownWhenConstraintMatchNotEnabled() {
+        DroolsScoreDirector<Object> director = new DroolsScoreDirector<>(mockDroolsScoreDirectorFactory(), false);
+        director.setWorkingSolution(new Object());
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("constraintMatchEnabled");
+        director.getConstraintMatchTotals();
+    }
+
+    @Test
+    public void constraintMatchTotalsNeverNull() {
+        DroolsScoreDirector<Object> director = new DroolsScoreDirector<>(mockDroolsScoreDirectorFactory(), true);
+        director.setWorkingSolution(new Object());
+        assertNotNull(director.getConstraintMatchTotals());
+    }
+
+    @SuppressWarnings("unchecked")
+    private DroolsScoreDirectorFactory<Object> mockDroolsScoreDirectorFactory() {
+        DroolsScoreDirectorFactory<Object> factory = mock(DroolsScoreDirectorFactory.class);
+        when(factory.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
+        when(factory.getSolutionDescriptor()).thenReturn(mock(SolutionDescriptor.class));
+        when(factory.newKieSession()).thenReturn(mock(KieSession.class));
+        return factory;
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/easy/EasyScoreDirectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/easy/EasyScoreDirectorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.score.director.easy;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.*;
+
+public class EasyScoreDirectorTest {
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void constraintMatchTotalsUnsupported() {
+        EasyScoreDirector<Object> director
+                = new EasyScoreDirector<>(mockEasyScoreDirectorFactory(), true, null);
+        assertFalse(director.isConstraintMatchEnabled());
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("not supported");
+        director.getConstraintMatchTotals();
+    }
+
+    @SuppressWarnings("unchecked")
+    private EasyScoreDirectorFactory<Object> mockEasyScoreDirectorFactory() {
+        EasyScoreDirectorFactory<Object> factory = mock(EasyScoreDirectorFactory.class);
+        when(factory.getSolutionDescriptor()).thenReturn(mock(SolutionDescriptor.class));
+        return factory;
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/incremental/IncrementalScoreDirectorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/incremental/IncrementalScoreDirectorTest.java
@@ -19,11 +19,14 @@ package org.optaplanner.core.impl.score.director.incremental;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.InOrder;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import org.optaplanner.core.impl.score.buildin.simple.SimpleScoreDefinition;
 import org.optaplanner.core.impl.testdata.domain.chained.rich.TestdataRichChainedAnchor;
 import org.optaplanner.core.impl.testdata.domain.chained.rich.TestdataRichChainedEntity;
 import org.optaplanner.core.impl.testdata.domain.chained.rich.TestdataRichChainedSolution;
@@ -32,6 +35,9 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class IncrementalScoreDirectorTest {
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void variableListener() {
@@ -81,6 +87,49 @@ public class IncrementalScoreDirectorTest {
         inOrder.verify(incrementalScoreCalculator, times(1)).beforeVariableChanged(b1, "nextEntity");
         inOrder.verify(incrementalScoreCalculator, times(1)).afterVariableChanged(b1, "nextEntity");
         inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void illegalStateExceptionThrownWhenConstraintMatchNotEnabled() {
+        IncrementalScoreDirector<Object> director
+                = new IncrementalScoreDirector<>(mockIncrementalScoreDirectorFactory(), false,
+                        mockIncrementalScoreCalculator(false));
+        director.setWorkingSolution(new Object());
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("constraintMatchEnabled");
+        director.getConstraintMatchTotals();
+    }
+
+    @Test
+    public void constraintMatchTotalsNeverNull() {
+        IncrementalScoreDirector<Object> director
+                = new IncrementalScoreDirector<>(mockIncrementalScoreDirectorFactory(), true,
+                        mockIncrementalScoreCalculator(true));
+        director.setWorkingSolution(new Object());
+        assertNotNull(director.getConstraintMatchTotals());
+    }
+
+    @Test
+    public void constraintMatchIsNotEnabledWhenScoreCalculatorNotConstraintMatchAware() {
+        IncrementalScoreDirector<Object> director
+                = new IncrementalScoreDirector<>(mockIncrementalScoreDirectorFactory(), true,
+                        mockIncrementalScoreCalculator(false));
+        assertFalse(director.isConstraintMatchEnabled());
+    }
+
+    @SuppressWarnings("unchecked")
+    private IncrementalScoreDirectorFactory<Object> mockIncrementalScoreDirectorFactory() {
+        IncrementalScoreDirectorFactory<Object> factory = mock(IncrementalScoreDirectorFactory.class);
+        when(factory.getScoreDefinition()).thenReturn(new SimpleScoreDefinition());
+        when(factory.getSolutionDescriptor()).thenReturn(mock(SolutionDescriptor.class));
+        return factory;
+    }
+
+    @SuppressWarnings("unchecked")
+    private IncrementalScoreCalculator<Object> mockIncrementalScoreCalculator(boolean constraintMatchAware) {
+        return constraintMatchAware
+                ? mock(ConstraintMatchAwareIncrementalScoreCalculator.class)
+                : mock(IncrementalScoreCalculator.class);
     }
 
 }


### PR DESCRIPTION
Contains a few minor JavaDoc fixes and makes all score directors throw
IllegalStateException from getConstraintMatchTotals() when
constraintMatchEnabled is false. Tests included.