### PR TITLE
Fix for difficulty comparator

### DIFF
--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/solver/ShiftAssignmentDifficultyComparator.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/nurserostering/domain/solver/ShiftAssignmentDifficultyComparator.java
@@ -30,10 +30,12 @@ public class ShiftAssignmentDifficultyComparator implements Comparator<ShiftAssi
         Shift aShift = a.getShift();
         Shift bShift = b.getShift();
         return new CompareToBuilder()
-                    .append(bShift.getShiftDate(), aShift.getShiftDate()) // Descending
-                    .append(bShift.getShiftType(), aShift.getShiftType()) // Descending
                     // For construction heuristics, scheduling the shifts in sequence is better
                     .append(aShift.getRequiredEmployeeSize(), bShift.getRequiredEmployeeSize())
+
+                    .append(bShift.getShiftDate(), aShift.getShiftDate()) // Descending
+                    .append(bShift.getShiftType(), aShift.getShiftType()) // Descending
+
                     .toComparison();
     }
 


### PR DESCRIPTION
ShiftDate and ShiftType comparisons are done by name and id. It make more sence to order shift assigments by RequiredEmployeeSize. It gives better results too.
