### PR TITLE
PLANNER-580 Make org.optaplanner.core.api.score.Score class hierarchy JavaScript-compile friendly

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/AbstractScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/AbstractScore.java
@@ -19,7 +19,6 @@ package org.optaplanner.core.api.score;
 import java.io.Serializable;
 import java.math.BigDecimal;
 
-import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 
 /**
@@ -176,11 +175,6 @@ public abstract class AbstractScore<S extends Score> implements Score<S>, Serial
     @Override
     public boolean isSolutionInitialized() {
         return initScore >= 0;
-    }
-
-    @Override
-    public boolean isCompatibleArithmeticArgument(Score otherScore) {
-        return getClass().isInstance(otherScore);
     }
 
     protected String getInitPrefix() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScore.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import org.optaplanner.core.api.score.AbstractBendableScore;
 import org.optaplanner.core.api.score.FeasibilityScore;
 import org.optaplanner.core.api.score.Score;
-import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.core.impl.score.buildin.bendablelong.BendableLongScoreDefinition;
 
 /**

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoft/HardMediumSoftScore.java
@@ -20,7 +20,6 @@ import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.score.AbstractScore;
 import org.optaplanner.core.api.score.FeasibilityScore;
 import org.optaplanner.core.api.score.Score;
-import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 
 /**
  * This {@link Score} is based on 3 levels of int constraints: hard, medium and soft.
@@ -230,6 +229,11 @@ public final class HardMediumSoftScore extends AbstractScore<HardMediumSoftScore
 
     public String toString() {
         return getInitPrefix() + hardScore + HARD_LABEL + "/" + mediumScore + MEDIUM_LABEL + "/" + softScore + SOFT_LABEL;
+    }
+
+    @Override
+    public boolean isCompatibleArithmeticArgument(Score otherScore) {
+        return otherScore instanceof HardMediumSoftScore;
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardmediumsoftlong/HardMediumSoftLongScore.java
@@ -233,4 +233,9 @@ public final class HardMediumSoftLongScore extends AbstractScore<HardMediumSoftL
         return getInitPrefix() + hardScore + HARD_LABEL + "/" + mediumScore + MEDIUM_LABEL + "/" + softScore + SOFT_LABEL;
     }
 
+    @Override
+    public boolean isCompatibleArithmeticArgument(Score otherScore) {
+        return otherScore instanceof HardMediumSoftLongScore;
+    }
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardsoft/HardSoftScore.java
@@ -198,4 +198,9 @@ public final class HardSoftScore extends AbstractScore<HardSoftScore> implements
         return getInitPrefix() + hardScore + HARD_LABEL + "/" + softScore + SOFT_LABEL;
     }
 
+    @Override
+    public boolean isCompatibleArithmeticArgument(Score otherScore) {
+        return otherScore instanceof HardSoftScore;
+    }
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScore.java
@@ -219,4 +219,9 @@ public final class HardSoftBigDecimalScore extends AbstractScore<HardSoftBigDeci
         return getInitPrefix() + hardScore + HARD_LABEL + "/" + softScore + SOFT_LABEL;
     }
 
+    @Override
+    public boolean isCompatibleArithmeticArgument(Score otherScore) {
+        return otherScore instanceof HardSoftBigDecimalScore;
+    }
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardsoftdouble/HardSoftDoubleScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardsoftdouble/HardSoftDoubleScore.java
@@ -19,7 +19,6 @@ package org.optaplanner.core.api.score.buildin.hardsoftdouble;
 import org.optaplanner.core.api.score.AbstractScore;
 import org.optaplanner.core.api.score.FeasibilityScore;
 import org.optaplanner.core.api.score.Score;
-import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
 import org.optaplanner.core.api.score.buildin.hardsoftbigdecimal.HardSoftBigDecimalScore;
 
 /**
@@ -203,6 +202,11 @@ public final class HardSoftDoubleScore extends AbstractScore<HardSoftDoubleScore
     @Override
     public String toString() {
         return getInitPrefix() + hardScore + HARD_LABEL + "/" + softScore + SOFT_LABEL;
+    }
+
+    @Override
+    public boolean isCompatibleArithmeticArgument(Score otherScore) {
+        return otherScore instanceof HardSoftDoubleScore;
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/hardsoftlong/HardSoftLongScore.java
@@ -200,4 +200,9 @@ public final class HardSoftLongScore extends AbstractScore<HardSoftLongScore>
         return getInitPrefix() + hardScore + HARD_LABEL + "/" + softScore + SOFT_LABEL;
     }
 
+    @Override
+    public boolean isCompatibleArithmeticArgument(Score otherScore) {
+        return otherScore instanceof HardSoftLongScore;
+    }
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/simple/SimpleScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/simple/SimpleScore.java
@@ -163,4 +163,9 @@ public final class SimpleScore extends AbstractScore<SimpleScore> {
         return getInitPrefix() + score;
     }
 
+    @Override
+    public boolean isCompatibleArithmeticArgument(Score otherScore) {
+        return otherScore instanceof SimpleScore;
+    }
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/simplebigdecimal/SimpleBigDecimalScore.java
@@ -180,4 +180,9 @@ public final class SimpleBigDecimalScore extends AbstractScore<SimpleBigDecimalS
         return getInitPrefix() + score;
     }
 
+    @Override
+    public boolean isCompatibleArithmeticArgument(Score otherScore) {
+        return otherScore instanceof SimpleBigDecimalScore;
+    }
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/simpledouble/SimpleDoubleScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/simpledouble/SimpleDoubleScore.java
@@ -168,4 +168,9 @@ public final class SimpleDoubleScore extends AbstractScore<SimpleDoubleScore> {
         return getInitPrefix() + score;
     }
 
+    @Override
+    public boolean isCompatibleArithmeticArgument(Score otherScore) {
+        return otherScore instanceof SimpleDoubleScore;
+    }
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/simplelong/SimpleLongScore.java
@@ -163,4 +163,9 @@ public final class SimpleLongScore extends AbstractScore<SimpleLongScore> {
         return getInitPrefix() + score;
     }
 
+    @Override
+    public boolean isCompatibleArithmeticArgument(Score otherScore) {
+        return otherScore instanceof SimpleLongScore;
+    }
+
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendable/BendableScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendable/BendableScoreTest.java
@@ -56,6 +56,14 @@ public class BendableScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    public void getHardOrSoftScore() {
+        BendableScore initializedScore = scoreDefinitionHSS.createScoreInitialized(-5, -10, -200);
+        assertEquals(-5, initializedScore.getHardOrSoftScore(0));
+        assertEquals(-10, initializedScore.getHardOrSoftScore(1));
+        assertEquals(-200, initializedScore.getHardOrSoftScore(2));
+    }
+
+    @Test
     public void toInitializedScoreHSS() {
         assertEquals(scoreDefinitionHSS.createScoreInitialized(-147, -258, -369),
                 scoreDefinitionHSS.createScoreInitialized(-147, -258, -369).toInitializedScore());

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScoreTest.java
@@ -91,6 +91,14 @@ public class BendableBigDecimalScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    public void getHardOrSoftScore() {
+        BendableBigDecimalScore initializedScore = scoreDefinitionHSS.createScoreInitialized(BigDecimal.valueOf(-5), BigDecimal.valueOf(-10), BigDecimal.valueOf(-200));
+        assertEquals(BigDecimal.valueOf(-5), initializedScore.getHardOrSoftScore(0));
+        assertEquals(BigDecimal.valueOf(-10), initializedScore.getHardOrSoftScore(1));
+        assertEquals(BigDecimal.valueOf(-200), initializedScore.getHardOrSoftScore(2));
+    }
+
+    @Test
     public void toInitializedScoreHSS() {
         assertEquals(scoreDefinitionHSS.createScoreInitialized(BigDecimal.valueOf(-147), BigDecimal.valueOf(-258), BigDecimal.valueOf(-369)),
                 scoreDefinitionHSS.createScoreInitialized(BigDecimal.valueOf(-147), BigDecimal.valueOf(-258), BigDecimal.valueOf(-369)).toInitializedScore());

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScoreTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScoreTest.java
@@ -50,6 +50,14 @@ public class BendableLongScoreTest extends AbstractScoreTest {
     }
 
     @Test
+    public void getHardOrSoftScore() {
+        BendableLongScore initializedScore = scoreDefinitionHSS.createScoreInitialized(-5L, -10L, -200L);
+        assertEquals(-5L, initializedScore.getHardOrSoftScore(0));
+        assertEquals(-10L, initializedScore.getHardOrSoftScore(1));
+        assertEquals(-200L, initializedScore.getHardOrSoftScore(2));
+    }
+
+    @Test
     public void toInitializedScoreHSS() {
         assertEquals(scoreDefinitionHSS.createScoreInitialized(-5432109876L, -9876543210L, -3456789012L),
                 scoreDefinitionHSS.createScoreInitialized(-5432109876L, -9876543210L, -3456789012L).toInitializedScore());


### PR DESCRIPTION
The PR relates to OptaPlanner Workbench. As `org.optaplanner.core.api.score.AbstractScore` uses `Class.isInstance()` method which is not supported by gwt compiler, a refactoring is required to be able to reuse the Score classes on the client-side of the WB. 