### PR TITLE
Add home page URL to all POMs

### DIFF
--- a/optaplanner-benchmark/pom.xml
+++ b/optaplanner-benchmark/pom.xml
@@ -20,6 +20,7 @@
 
     This module contains the benchmarker toolkit.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <properties>
     <osgi.Bundle-SymbolicName>org.optaplanner.benchmark</osgi.Bundle-SymbolicName>

--- a/optaplanner-core/pom.xml
+++ b/optaplanner-core/pom.xml
@@ -20,6 +20,7 @@
 
     This module contains the planning engine itself.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <properties>
     <osgi.Bundle-SymbolicName>org.optaplanner.core</osgi.Bundle-SymbolicName>

--- a/optaplanner-distribution/pom.xml
+++ b/optaplanner-distribution/pom.xml
@@ -20,6 +20,7 @@
 
     This module builds the download zip.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <build>
     <plugins>

--- a/optaplanner-docs/pom.xml
+++ b/optaplanner-docs/pom.xml
@@ -21,6 +21,7 @@
 
     This module builds the documentation.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <build>
     <pluginManagement>

--- a/optaplanner-examples/pom.xml
+++ b/optaplanner-examples/pom.xml
@@ -19,6 +19,7 @@
 
     This module contains the non-web examples which demonstrate how to use it in a normal Java application.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <repositories>
     <!-- TODO remove this once maven central replicates the jboss repository -->

--- a/optaplanner-persistence/optaplanner-persistence-common/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-common/pom.xml
@@ -20,6 +20,7 @@
 
     This module contains the common persistence integration.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <properties>
     <osgi.Bundle-SymbolicName>org.optaplanner.persistence.common</osgi.Bundle-SymbolicName>

--- a/optaplanner-persistence/optaplanner-persistence-jackson/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jackson/pom.xml
@@ -20,6 +20,7 @@
 
     This module contains the jackson integration.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <properties>
     <osgi.Bundle-SymbolicName>org.optaplanner.persistence.jackson</osgi.Bundle-SymbolicName>

--- a/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jaxb/pom.xml
@@ -20,6 +20,7 @@
 
     This module contains the JAXB integration.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <properties>
     <osgi.Bundle-SymbolicName>org.optaplanner.persistence.jaxb</osgi.Bundle-SymbolicName>

--- a/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-jpa/pom.xml
@@ -20,6 +20,7 @@
 
     This module contains the JPA and Hibernate integration.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <dependencies>
     <!-- Internal dependencies -->

--- a/optaplanner-persistence/optaplanner-persistence-xstream/pom.xml
+++ b/optaplanner-persistence/optaplanner-persistence-xstream/pom.xml
@@ -20,6 +20,7 @@
 
     This module contains the XStream integration.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <properties>
     <osgi.Bundle-SymbolicName>org.optaplanner.persistence.xstream</osgi.Bundle-SymbolicName>

--- a/optaplanner-persistence/pom.xml
+++ b/optaplanner-persistence/pom.xml
@@ -20,6 +20,7 @@
 
     This module contains the persistence modules.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <modules>
     <module>optaplanner-persistence-common</module>

--- a/optaplanner-test/pom.xml
+++ b/optaplanner-test/pom.xml
@@ -20,6 +20,7 @@
     This module contains the JUnit and other test support.
     This module is intended to be used a test scoped dependency.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <dependencies>
     <!-- Internal dependencies -->

--- a/optaplanner-webexamples/pom.xml
+++ b/optaplanner-webexamples/pom.xml
@@ -20,6 +20,7 @@
 
     This module contains the web examples which demonstrate how to use it in a war file.
   </description>
+  <url>http://www.optaplanner.org</url>
 
   <properties>
     <!-- Overwrite ip-bom's jboss-logging version of EAP 6.4 to allow Arquillian test to work on WildFly 9 -->


### PR DESCRIPTION
There is a lot of artifacts under the `optaplanner.org` group ID but only `optaplanner` (the parent module) contains URL of www.optaplanner.org. When people search for OptaPlanner JARs they will probably look for optaplanner-core, optaplanner-benchmark etc. on mvnrepository.com where the URL is shown as a HomePage just after the artifact description. So why not providing a one-click access to www.optaplanner.org for people that possibly don't know about it? Is it a good idea?

Result:
![maven repository org optaplanner optaplanner 7 0 0 beta1 - mozilla firefox_007](https://cloud.githubusercontent.com/assets/673386/17909009/ef5087f0-6982-11e6-819d-7c608efdd6b9.png)
