### PR TITLE
PLANNER-647 Workbench: Include ErraiApp.properties and score marshalling mappings in workbench-upstream-model module

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendable/BendableScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendable/BendableScore.java
@@ -105,7 +105,15 @@ public final class BendableScore extends AbstractBendableScore<BendableScore>
         this.softScores = softScores;
     }
 
-    // Intentionally no getters for the hardScores or softScores int arrays to guarantee that this class is immutable
+    public int[] getHardScores() {
+        // return copy of the array to guarantee that this class is immutable
+        return Arrays.copyOf(hardScores, hardScores.length);
+    }
+
+    public int[] getSoftScores() {
+        // return copy of the array to guarantee that this class is immutable
+        return Arrays.copyOf(softScores, softScores.length);
+    }
 
     @Override
     public int getHardLevelsSize() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendablebigdecimal/BendableBigDecimalScore.java
@@ -107,7 +107,15 @@ public final class BendableBigDecimalScore extends AbstractBendableScore<Bendabl
         this.softScores = softScores;
     }
 
-    // Intentionally no getters for the hardScores or softScores int arrays to guarantee that this class is immutable
+    public BigDecimal[] getHardScores() {
+        // return copy of the array to guarantee that this class is immutable
+        return Arrays.copyOf(hardScores, hardScores.length);
+    }
+
+    public BigDecimal[] getSoftScores() {
+        // return copy of the array to guarantee that this class is immutable
+        return Arrays.copyOf(softScores, softScores.length);
+    }
 
     @Override
     public int getHardLevelsSize() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScore.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/buildin/bendablelong/BendableLongScore.java
@@ -105,7 +105,15 @@ public final class BendableLongScore extends AbstractBendableScore<BendableLongS
         this.softScores = softScores;
     }
 
-    // Intentionally no getters for the hardScores or softScores int arrays to guarantee that this class is immutable
+    public long[] getHardScores() {
+        // return copy of the array to guarantee that this class is immutable
+        return Arrays.copyOf(hardScores, hardScores.length);
+    }
+
+    public long[] getSoftScores() {
+        // return copy of the array to guarantee that this class is immutable
+        return Arrays.copyOf(softScores, softScores.length);
+    }
 
     @Override
     public int getHardLevelsSize() {


### PR DESCRIPTION
As the scores are value classes, custom errai mapping needs to be defined for them if they are ever to be used in Errai services. The problem with Bendable*Score types is that they don't expose hardScores & softScores variables, therefore it's not possible to marshall such value.
This PR adds getters for aforementioned variables. @ge0ffrey Are you ok with such change?  