### PR TITLE
PLANNER-536 Workbench solver editor: bendable score combobox selection should allow filling in hard and soft level size

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -399,7 +399,8 @@ public class SolutionDescriptor<Solution_> {
                         + " or scoreDefinitionClass element.\n"
                         + "  Maybe remove the <scoreDefinitionType>, <bendableHardLevelsSize>, <bendableSoftLevelsSize> and <scoreDefinitionClass> elements from the solver configuration.");
             }
-            if (scoreMemberAccessor != null) {
+            // scoreMemberAccessor can be set if accessor method is overriden in AbstractSolution subclass
+            if (scoreMemberAccessor != null && !AbstractSolution.class.isAssignableFrom(solutionClass)) {
                 throw new IllegalStateException("The solutionClass (" + solutionClass
                         + ") has a " + PlanningScore.class.getSimpleName()
                         + " annotated member (" + memberAccessor
@@ -410,9 +411,12 @@ public class SolutionDescriptor<Solution_> {
                         + ") has a " + PlanningScore.class.getSimpleName()
                         + " annotated member (" + memberAccessor + ") that does not return a subtype of Score.");
             }
-            scoreMemberAccessor = memberAccessor;
+            // Prefer Score accessor methods at the bottom of the object hierarchy
+            if (scoreMemberAccessor == null) {
+                scoreMemberAccessor = memberAccessor;
+            }
             Class<? extends Score> scoreType = (Class<? extends Score>) scoreMemberAccessor.getType();
-            PlanningScore annotation = memberAccessor.getAnnotation(PlanningScore.class);
+            PlanningScore annotation = scoreMemberAccessor.getAnnotation(PlanningScore.class);
             scoreDefinition = buildScoreDefinition(scoreType, annotation);
         }
     }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptorTest.java
@@ -23,6 +23,7 @@ import org.optaplanner.core.impl.testdata.domain.collection.TestdataArrayBasedSo
 import org.optaplanner.core.impl.testdata.domain.collection.TestdataSetBasedSolution;
 import org.optaplanner.core.impl.testdata.domain.extended.TestdataAnnotatedExtendedSolution;
 import org.optaplanner.core.impl.testdata.domain.extended.abstractsolution.TestdataExtendedAbstractSolution;
+import org.optaplanner.core.impl.testdata.domain.extended.abstractsolution.TestdataExtendedAbstractSolutionOverridenScoreAccessors;
 import org.optaplanner.core.impl.testdata.domain.extended.legacysolution.TestdataLegacySolution;
 import org.optaplanner.core.impl.testdata.domain.reflect.generic.TestdataGenericSolution;
 import org.optaplanner.core.impl.testdata.domain.solutionproperties.TestdataNoProblemFactPropertySolution;
@@ -153,6 +154,12 @@ public class SolutionDescriptorTest {
         assertMapContainsKeysExactly(solutionDescriptor.getEntityMemberAccessorMap());
         assertMapContainsKeysExactly(solutionDescriptor.getEntityCollectionMemberAccessorMap(),
                 "entityList");
+    }
+
+    @Test
+    public void extendedAbstractSolutionOverridenScoreAccessors() {
+        SolutionDescriptor<TestdataExtendedAbstractSolutionOverridenScoreAccessors> solutionDescriptor
+                = TestdataExtendedAbstractSolutionOverridenScoreAccessors.buildSolutionDescriptor();
     }
 
     @Test @Deprecated

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/solver/DefaultSolverTest.java
@@ -61,7 +61,7 @@ public class DefaultSolverTest {
                 .setScoreDefinitionType(ScoreDefinitionType.SIMPLE);
         Solver<TestdataLegacySolution> solver = solverFactory.buildSolver();
 
-        TestdataLegacySolution solution = new TestdataLegacySolution("s1");
+        TestdataLegacySolution solution = new TestdataLegacySolution();
         solution.setValueList(Arrays.asList(new TestdataValue("v1"), new TestdataValue("v2")));
         solution.setEntityList(Arrays.asList(new TestdataEntity("e1"), new TestdataEntity("e2")));
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/extended/abstractsolution/TestdataExtendedAbstractSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/extended/abstractsolution/TestdataExtendedAbstractSolution.java
@@ -39,8 +39,7 @@ public class TestdataExtendedAbstractSolution extends AbstractSolution<HardSoftS
 
     private List<TestdataEntity> entityList;
 
-    public TestdataExtendedAbstractSolution(String code) {
-        super();
+    public TestdataExtendedAbstractSolution() {
     }
 
     @ValueRangeProvider(id = "valueRange")

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/extended/abstractsolution/TestdataExtendedAbstractSolutionOverridenScoreAccessors.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/extended/abstractsolution/TestdataExtendedAbstractSolutionOverridenScoreAccessors.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,35 +14,34 @@
  * limitations under the License.
  */
 
-package org.optaplanner.core.impl.testdata.domain.extended.legacysolution;
+package org.optaplanner.core.impl.testdata.domain.extended.abstractsolution;
 
-import java.util.Collection;
 import java.util.List;
 
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.solution.Solution;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
-import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.api.score.buildin.bendable.BendableScore;
+import org.optaplanner.core.impl.domain.solution.AbstractSolution;
 import org.optaplanner.core.impl.domain.solution.descriptor.SolutionDescriptor;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 
 @PlanningSolution
-@Deprecated
-public class TestdataLegacySolution implements Solution<SimpleScore> {
+public class TestdataExtendedAbstractSolutionOverridenScoreAccessors extends AbstractSolution<BendableScore> {
 
     public static SolutionDescriptor buildSolutionDescriptor() {
-        return SolutionDescriptor.buildSolutionDescriptor(TestdataLegacySolution.class, TestdataEntity.class);
+        return SolutionDescriptor.buildSolutionDescriptor(TestdataExtendedAbstractSolutionOverridenScoreAccessors.class, TestdataEntity.class);
     }
 
     private List<TestdataValue> valueList;
+    private Object extraObject;
 
     private List<TestdataEntity> entityList;
 
-    private SimpleScore score;
-
-    public TestdataLegacySolution() {}
+    public TestdataExtendedAbstractSolutionOverridenScoreAccessors() {
+    }
 
     @ValueRangeProvider(id = "valueRange")
     public List<TestdataValue> getValueList() {
@@ -51,6 +50,14 @@ public class TestdataLegacySolution implements Solution<SimpleScore> {
 
     public void setValueList(List<TestdataValue> valueList) {
         this.valueList = valueList;
+    }
+
+    public Object getExtraObject() {
+        return extraObject;
+    }
+
+    public void setExtraObject(Object extraObject) {
+        this.extraObject = extraObject;
     }
 
     @PlanningEntityCollectionProperty
@@ -63,22 +70,18 @@ public class TestdataLegacySolution implements Solution<SimpleScore> {
     }
 
     @Override
-    public SimpleScore getScore() {
+    @PlanningScore(bendableHardLevelsSize = 5, bendableSoftLevelsSize = 5)
+    public BendableScore getScore() {
         return score;
     }
 
     @Override
-    public void setScore(SimpleScore score) {
+    public void setScore(BendableScore score) {
         this.score = score;
     }
 
     // ************************************************************************
     // Complex methods
     // ************************************************************************
-
-    @Override
-    public Collection<?> getProblemFacts() {
-        return valueList;
-    }
 
 }


### PR DESCRIPTION
The changes are required to allow score getter/setter overriding in `AbstractSolution` subclass. This is used by the Workbench when working with bendable score types to define `@PlanningScore` with respective `bendable(Hard|Soft)LevelsSize` annotation values.  