### PR TITLE
TestGen fixes

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenDroolsScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenDroolsScoreDirector.java
@@ -18,12 +18,16 @@ package org.optaplanner.core.impl.score.director.drools.testgen;
 import java.io.File;
 import java.util.Collection;
 
+import org.kie.api.runtime.KieSession;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.constraint.ConstraintMatchTotal;
+import org.optaplanner.core.api.score.holder.ScoreHolder;
 import org.optaplanner.core.impl.domain.entity.descriptor.EntityDescriptor;
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
+import org.optaplanner.core.impl.score.definition.ScoreDefinition;
 import org.optaplanner.core.impl.score.director.drools.DroolsScoreDirector;
 import org.optaplanner.core.impl.score.director.drools.DroolsScoreDirectorFactory;
+import org.optaplanner.core.impl.score.director.drools.testgen.reproducer.TestGenCorruptedScoreException;
 import org.optaplanner.core.impl.score.director.drools.testgen.reproducer.TestGenCorruptedScoreReproducer;
 import org.optaplanner.core.impl.score.director.drools.testgen.reproducer.TestGenDroolsExceptionReproducer;
 
@@ -34,6 +38,19 @@ public class TestGenDroolsScoreDirector<Solution_> extends DroolsScoreDirector<S
 
     public TestGenDroolsScoreDirector(DroolsScoreDirectorFactory<Solution_> scoreDirectorFactory, boolean constraintMatchEnabledPreference) {
         super(scoreDirectorFactory, constraintMatchEnabledPreference);
+    }
+
+    public KieSession createKieSession() {
+        KieSession newKieSession = getScoreDirectorFactory().newKieSession();
+
+        // set a fresh score holder
+        ScoreDefinition<?> scoreDefinition = getScoreDefinition();
+        if (scoreDefinition != null) {
+            ScoreHolder sh = scoreDefinition.buildScoreHolder(constraintMatchEnabledPreference);
+            newKieSession.setGlobal(DroolsScoreDirector.GLOBAL_SCORE_HOLDER_KEY, sh);
+        }
+
+        return newKieSession;
     }
 
     @Override
@@ -55,7 +72,8 @@ public class TestGenDroolsScoreDirector<Solution_> extends DroolsScoreDirector<S
         } catch (RuntimeException e) {
             // catch any Drools exception and create a minimal reproducing test
             // TODO check the exception is coming from org.drools
-            TestGenKieSessionJournal minJournal = TestGenerator.minimize(journal, new TestGenDroolsExceptionReproducer(e, kieSession));
+            TestGenDroolsExceptionReproducer reproducer = new TestGenDroolsExceptionReproducer(e, this);
+            TestGenKieSessionJournal minJournal = TestGenerator.minimize(journal, reproducer);
             TestGenTestWriter.print(minJournal, testFile);
             throw wrapOriginalException(e);
         }
@@ -68,14 +86,20 @@ public class TestGenDroolsScoreDirector<Solution_> extends DroolsScoreDirector<S
         } catch (IllegalStateException e) {
             // catch corrupted score exception and create a minimal reproducing test
             // TODO check it's really corrupted score
-            TestGenCorruptedScoreReproducer reproducer = new TestGenCorruptedScoreReproducer(
-                    e.getMessage(),
-                    kieSession,
-                    getScoreDefinition(),
-                    constraintMatchEnabledPreference
-            );
+            TestGenCorruptedScoreReproducer reproducer = new TestGenCorruptedScoreReproducer(e.getMessage(), this);
             TestGenKieSessionJournal minJournal = TestGenerator.minimize(journal, reproducer);
-            TestGenTestWriter.print(minJournal, testFile);
+            Score<?> uncorruptedScore = workingScore;
+            try {
+                minJournal.replay(createKieSession());
+            } catch (TestGenCorruptedScoreException tgcse) {
+                uncorruptedScore = tgcse.getUncorruptedScore();
+            }
+            TestGenTestWriter.printWithScoreAssert(
+                    minJournal,
+                    getScoreDefinition().getClass(),
+                    constraintMatchEnabledPreference,
+                    uncorruptedScore.toString(),
+                    testFile);
             throw wrapOriginalException(e);
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionEventSupport.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionEventSupport.java
@@ -21,9 +21,9 @@ import org.optaplanner.core.impl.solver.event.AbstractEventSupport;
 public class TestGenKieSessionEventSupport extends AbstractEventSupport<TestGenKieSessionListener> implements TestGenKieSessionListener {
 
     @Override
-    public void afterFireAllRules(KieSession kieSession) {
+    public void afterFireAllRules(KieSession kieSession, TestGenKieSessionJournal journal) {
         for (TestGenKieSessionListener listener : eventListenerSet) {
-            listener.afterFireAllRules(kieSession);
+            listener.afterFireAllRules(kieSession, journal);
         }
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionJournal.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionJournal.java
@@ -34,7 +34,7 @@ import org.optaplanner.core.impl.score.director.drools.testgen.operation.TestGen
 public class TestGenKieSessionJournal {
 
     private final TestGenKieSessionEventSupport eventSupport = new TestGenKieSessionEventSupport();
-    private final HashMap<Object, TestGenFact> existingInstances = new HashMap<Object, TestGenFact>();
+    private final HashMap<Object, TestGenFact> existingInstances = new HashMap<>();
     private final List<TestGenFact> facts;
     private final List<TestGenKieSessionInsert> initialInsertJournal;
     private final List<TestGenKieSessionOperation> updateJournal;
@@ -69,7 +69,7 @@ public class TestGenKieSessionJournal {
                 op.invoke(replayKieSession);
                 // detect corrupted score after firing rules
                 if (op.getClass().equals(TestGenKieSessionFireAllRules.class)) {
-                    eventSupport.afterFireAllRules(replayKieSession);
+                    eventSupport.afterFireAllRules(replayKieSession, this);
                 }
             }
         } catch (RuntimeException ex) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionListener.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionListener.java
@@ -21,5 +21,5 @@ import org.kie.api.runtime.KieSession;
 
 public interface TestGenKieSessionListener extends EventListener {
 
-    void afterFireAllRules(KieSession kieSession);
+    void afterFireAllRules(KieSession kieSession, TestGenKieSessionJournal journal);
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenAbstractValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenAbstractValueProvider.java
@@ -15,16 +15,16 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
-abstract class TestGenAbstractValueProvider implements TestGenValueProvider {
+abstract class TestGenAbstractValueProvider<T> implements TestGenValueProvider<T> {
 
-    protected final Object value;
+    protected final T value;
 
-    public TestGenAbstractValueProvider(Object value) {
+    public TestGenAbstractValueProvider(T value) {
         this.value = value;
     }
 
     @Override
-    public Object get() {
+    public T get() {
         return value;
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenEnumValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenEnumValueProvider.java
@@ -15,15 +15,15 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
-class TestGenEnumValueProvider extends TestGenAbstractValueProvider {
+class TestGenEnumValueProvider extends TestGenAbstractValueProvider<Enum<?>> {
 
-    public TestGenEnumValueProvider(Object value) {
+    public TestGenEnumValueProvider(Enum<?> value) {
         super(value);
     }
 
     @Override
     public String toString() {
-        return value.getClass().getSimpleName() + "." + ((Enum) value).name();
+        return value.getClass().getSimpleName() + "." + value.name();
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenExistingInstanceValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenExistingInstanceValueProvider.java
@@ -15,7 +15,7 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
-class TestGenExistingInstanceValueProvider extends TestGenAbstractValueProvider {
+class TestGenExistingInstanceValueProvider extends TestGenAbstractValueProvider<Object> {
 
     private final String identifier;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenListValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenListValueProvider.java
@@ -20,28 +20,25 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-class TestGenListValueProvider extends TestGenAbstractValueProvider {
+class TestGenListValueProvider extends TestGenAbstractValueProvider<List<?>> {
 
     private final String identifier;
     private final Type typeArgument;
     private final Map<Object, TestGenFact> existingInstances;
     private final List<Class<?>> imports = new ArrayList<>();
 
-    public TestGenListValueProvider(Object value, String identifier, Type genericType, Map<Object, TestGenFact> existingInstances) {
+    public TestGenListValueProvider(List<?> value, String identifier, Type genericType, Map<Object, TestGenFact> existingInstances) {
         super(value);
         this.identifier = identifier;
         this.typeArgument = genericType;
         this.existingInstances = existingInstances;
         imports.add(ArrayList.class);
         imports.add((Class<?>) genericType);
-        for (Object item : ((java.util.List<?>) value)) {
-            imports.add(item.getClass());
-        }
     }
 
     public List<TestGenFact> getFacts() {
-        ArrayList<TestGenFact> facts = new ArrayList<TestGenFact>();
-        for (Object o : (List<?>) value) {
+        ArrayList<TestGenFact> facts = new ArrayList<>();
+        for (Object o : value) {
             TestGenFact fact = existingInstances.get(o);
             if (fact != null) {
                 facts.add(fact);
@@ -58,7 +55,7 @@ class TestGenListValueProvider extends TestGenAbstractValueProvider {
     public void printSetup(StringBuilder sb) {
         String e = ((Class<?>) typeArgument).getSimpleName();
         sb.append(String.format("        ArrayList<%s> %s = new ArrayList<%s>();%n", e, identifier, e));
-        for (Object item : ((java.util.List<?>) value)) {
+        for (Object item : value) {
             sb.append(String.format("        //%s%n", item));
             sb.append(String.format("        %s.add(%s);%n", identifier, existingInstances.get(item)));
         }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenMapValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenMapValueProvider.java
@@ -21,14 +21,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-class TestGenMapValueProvider extends TestGenAbstractValueProvider {
+class TestGenMapValueProvider extends TestGenAbstractValueProvider<Map<?, ?>> {
 
     private final String identifier;
     private final Type[] typeArguments;
     private final Map<Object, TestGenFact> existingInstances;
     private final List<Class<?>> imports = new ArrayList<>();
 
-    public TestGenMapValueProvider(Object value, String identifier,
+    public TestGenMapValueProvider(Map<?, ?> value, String identifier,
             Type[] typeArguments, Map<Object, TestGenFact> existingInstances) {
         super(value);
         this.identifier = identifier;
@@ -37,15 +37,11 @@ class TestGenMapValueProvider extends TestGenAbstractValueProvider {
         imports.add(HashMap.class);
         imports.add((Class<?>) typeArguments[0]);
         imports.add((Class<?>) typeArguments[1]);
-        for (Map.Entry<? extends Object, ? extends Object> entry : ((java.util.Map<?, ?>) value).entrySet()) {
-            imports.add(entry.getKey().getClass());
-            imports.add(entry.getValue().getClass());
-        }
     }
 
     public List<TestGenFact> getFacts() {
-        ArrayList<TestGenFact> facts = new ArrayList<TestGenFact>();
-        for (Map.Entry<? extends Object, ? extends Object> entry : ((java.util.Map<?, ?>) value).entrySet()) {
+        ArrayList<TestGenFact> facts = new ArrayList<>();
+        for (Map.Entry<? extends Object, ? extends Object> entry : value.entrySet()) {
             addFact(facts, entry.getKey());
             addFact(facts, entry.getValue());
         }
@@ -68,7 +64,7 @@ class TestGenMapValueProvider extends TestGenAbstractValueProvider {
         String k = ((Class<?>) typeArguments[0]).getSimpleName();
         String v = ((Class<?>) typeArguments[1]).getSimpleName();
         sb.append(String.format("        HashMap<%s, %s> %s = new HashMap<%s, %s>();%n", k, v, identifier, k, v));
-        for (Map.Entry<? extends Object, ? extends Object> entry : ((java.util.Map<?, ?>) value).entrySet()) {
+        for (Map.Entry<? extends Object, ? extends Object> entry : value.entrySet()) {
             sb.append(String.format("        //%s => %s%n", entry.getKey(), entry.getValue()));
             sb.append(String.format("        %s.put(%s, %s);%n", identifier, existingInstances.get(entry.getKey()), existingInstances.get(entry.getValue())));
         }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenNullValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenNullValueProvider.java
@@ -15,7 +15,7 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
-class TestGenNullValueProvider extends TestGenAbstractValueProvider {
+class TestGenNullValueProvider extends TestGenAbstractValueProvider<Object> {
 
     public TestGenNullValueProvider() {
         super(null);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenParsedValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenParsedValueProvider.java
@@ -17,7 +17,7 @@ package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
 import java.lang.reflect.Method;
 
-class TestGenParsedValueProvider extends TestGenAbstractValueProvider {
+class TestGenParsedValueProvider extends TestGenAbstractValueProvider<Object> {
 
     private final Method parseMethod;
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenPrimitiveValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenPrimitiveValueProvider.java
@@ -15,7 +15,7 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
-class TestGenPrimitiveValueProvider extends TestGenAbstractValueProvider {
+class TestGenPrimitiveValueProvider extends TestGenAbstractValueProvider<Object> {
 
     public TestGenPrimitiveValueProvider(Object value) {
         super(value);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenStringValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenStringValueProvider.java
@@ -15,15 +15,15 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
-class TestGenStringValueProvider extends TestGenAbstractValueProvider {
+class TestGenStringValueProvider extends TestGenAbstractValueProvider<String> {
 
-    public TestGenStringValueProvider(Object value) {
+    public TestGenStringValueProvider(String value) {
         super(value);
     }
 
     @Override
     public String toString() {
-        return '"' + (String) value + '"';
+        return '"' + value + '"';
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueProvider.java
@@ -15,9 +15,9 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
-interface TestGenValueProvider {
+interface TestGenValueProvider<T> {
 
-    Object get();
+    T get();
 
     void printSetup(StringBuilder sb);
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/mutation/TestGenRemoveRandomBlockMutator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/mutation/TestGenRemoveRandomBlockMutator.java
@@ -29,7 +29,7 @@ public class TestGenRemoveRandomBlockMutator<T> {
     private List<T> removedBlock;
 
     public TestGenRemoveRandomBlockMutator(List<T> list) {
-        this.list = new ArrayList<T>(list);
+        this.list = new ArrayList<>(list);
     }
 
     public boolean canMutate() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionFireAllRules.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionFireAllRules.java
@@ -16,9 +16,12 @@
 package org.optaplanner.core.impl.score.director.drools.testgen.operation;
 
 import org.kie.api.runtime.KieSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestGenKieSessionFireAllRules implements TestGenKieSessionOperation {
 
+    private static final Logger logger = LoggerFactory.getLogger(TestGenKieSessionFireAllRules.class);
     private final int id;
 
     public TestGenKieSessionFireAllRules(int id) {
@@ -27,6 +30,7 @@ public class TestGenKieSessionFireAllRules implements TestGenKieSessionOperation
 
     @Override
     public void invoke(KieSession kieSession) {
+        logger.trace("        FIRE");
         kieSession.fireAllRules();
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionUpdate.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionUpdate.java
@@ -24,9 +24,12 @@ import org.optaplanner.core.impl.domain.common.accessor.BeanPropertyMemberAccess
 import org.optaplanner.core.impl.domain.variable.descriptor.VariableDescriptor;
 import org.optaplanner.core.impl.score.director.drools.testgen.fact.TestGenFact;
 import org.optaplanner.core.impl.score.director.drools.testgen.fact.TestGenNullFact;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestGenKieSessionUpdate implements TestGenKieSessionOperation {
 
+    private static final Logger logger = LoggerFactory.getLogger(TestGenKieSessionUpdate.class);
     private final int id;
     private final TestGenFact entity;
     private final BeanPropertyMemberAccessor accessor;
@@ -60,6 +63,7 @@ public class TestGenKieSessionUpdate implements TestGenKieSessionOperation {
 
     @Override
     public void invoke(KieSession kieSession) {
+        logger.trace("        {} ← {}", entity.getInstance(), value.getInstance());
         accessor.executeSetter(entity.getInstance(), value.getInstance());
         FactHandle fh = kieSession.getFactHandle(entity.getInstance());
         if (fh == null) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreException.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreException.java
@@ -15,20 +15,27 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.reproducer;
 
-class TestGenCorruptedScoreException extends RuntimeException {
+import org.optaplanner.core.api.score.Score;
 
-    /**
-     * Creates a new instance of <code>CorruptedScoreException</code> without detail message.
-     */
-    public TestGenCorruptedScoreException() {
+public class TestGenCorruptedScoreException extends RuntimeException {
+
+    private static final long serialVersionUID = -8432764392597925152L;
+
+    private final Score<?> workingScore;
+    private final Score<?> uncorruptedScore;
+
+    public TestGenCorruptedScoreException(Score<?> workingScore, Score<?> uncorruptedScore) {
+        super("Working: " + workingScore + ", uncorrupted: " + uncorruptedScore);
+        this.workingScore = workingScore;
+        this.uncorruptedScore = uncorruptedScore;
     }
 
-    /**
-     * Constructs an instance of <code>CorruptedScoreException</code> with the specified detail message.
-     *
-     * @param msg the detail message.
-     */
-    public TestGenCorruptedScoreException(String msg) {
-        super(msg);
+    public Score<?> getWorkingScore() {
+        return workingScore;
     }
+
+    public Score<?> getUncorruptedScore() {
+        return uncorruptedScore;
+    }
+
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.score.director.drools.testgen.fact;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+
+import static org.junit.Assert.*;
+
+public class TestGenValueFactTest {
+
+    @Test
+    public void initialization() {
+        TestdataValue instance = new TestdataValue();
+        TestGenValueFact fact = new TestGenValueFact(321, instance);
+
+        assertSame(instance, fact.getInstance());
+        assertEquals("testdataValue_321", fact.toString());
+
+        StringBuilder sb = new StringBuilder(100);
+        fact.printInitialization(sb);
+        assertEquals("    TestdataValue testdataValue_321 = new TestdataValue();\n", sb.toString());
+    }
+
+    @Test
+    public void importsAndDependencies() {
+        HashMap<Object, TestGenFact> instances = new HashMap<>();
+        TestdataEntity entity = new TestdataEntity();
+        TestGenValueFact f1 = new TestGenValueFact(0, entity);
+        TestdataValue value = new TestdataValue();
+        TestGenValueFact f2 = new TestGenValueFact(1, value);
+
+        instances.put(entity, f1);
+
+        f1.setUp(instances);
+        assertEquals(1, f1.getImports().size());
+        assertTrue(f1.getImports().contains(TestdataEntity.class));
+        assertEquals(0, f1.getDependencies().size());
+
+        entity.setValue(value);
+        instances.put(value, f2);
+
+        f2.setUp(instances);
+        assertEquals(1, f2.getImports().size());
+        assertTrue(f2.getImports().contains(TestdataValue.class));
+        assertTrue(f1.getDependencies().isEmpty());
+
+
+        f1.setUp(instances);
+        assertEquals(1, f1.getImports().size());
+        assertTrue(f1.getImports().contains(TestdataEntity.class));
+        assertEquals(1, f1.getDependencies().size());
+        assertTrue(f1.getDependencies().contains(f2));
+    }
+
+}


### PR DESCRIPTION
- improve imports handling
- fix: when calculating uncorrupted score, only insert problem facts, not all objects from the working session
- consistently name Logger fields
- use diamond operator