### PR TITLE
BZ-1139670 Add test coverage for corrupted cloner detection

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/domain/solution/cloner/CustomSolutionClonerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/domain/solution/cloner/CustomSolutionClonerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.api.domain.solution.cloner;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.config.solver.EnvironmentMode;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.customcloner.TestdataCorrectlyClonedSolution;
+import org.optaplanner.core.impl.testdata.domain.customcloner.TestdataEntitiesNotClonedSolution;
+import org.optaplanner.core.impl.testdata.domain.customcloner.TestdataScoreNotEqualSolution;
+import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
+
+public class CustomSolutionClonerTest {
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void correctCloner() {
+        SolverFactory<TestdataCorrectlyClonedSolution> factory = PlannerTestUtils.buildSolverFactory(
+                TestdataCorrectlyClonedSolution.class, TestdataEntity.class);
+        SolverConfig solverConfig = factory.getSolverConfig();
+        solverConfig.setEnvironmentMode(EnvironmentMode.NON_INTRUSIVE_FULL_ASSERT);
+
+        TestdataCorrectlyClonedSolution solution = new TestdataCorrectlyClonedSolution();
+        factory.buildSolver().solve(solution);
+    }
+
+    @Test
+    public void scoreNotEqual() {
+        SolverFactory<TestdataScoreNotEqualSolution> factory = PlannerTestUtils.buildSolverFactory(
+                TestdataScoreNotEqualSolution.class, TestdataEntity.class);
+        SolverConfig solverConfig = factory.getSolverConfig();
+        solverConfig.setEnvironmentMode(EnvironmentMode.NON_INTRUSIVE_FULL_ASSERT);
+
+        TestdataScoreNotEqualSolution solution = new TestdataScoreNotEqualSolution();
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Cloning corruption: the original's score ");
+        factory.buildSolver().solve(solution);
+    }
+
+    @Test
+    public void entitiesNotCloned() {
+        SolverFactory<TestdataEntitiesNotClonedSolution> factory = PlannerTestUtils.buildSolverFactory(
+                TestdataEntitiesNotClonedSolution.class, TestdataEntity.class);
+        SolverConfig solverConfig = factory.getSolverConfig();
+        solverConfig.setEnvironmentMode(EnvironmentMode.NON_INTRUSIVE_FULL_ASSERT);
+
+        TestdataEntitiesNotClonedSolution solution = new TestdataEntitiesNotClonedSolution();
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Cloning corruption: the same entity ");
+        factory.buildSolver().solve(solution);
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataCorrectlyClonedSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataCorrectlyClonedSolution.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.testdata.domain.customcloner;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.cloner.SolutionCloner;
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+
+@PlanningSolution(solutionCloner = TestdataCorrectlyClonedSolution.class)
+public class TestdataCorrectlyClonedSolution implements SolutionCloner<TestdataCorrectlyClonedSolution> {
+
+    @PlanningScore
+    private SimpleScore score;
+    @PlanningEntityProperty
+    private TestdataEntity entity = new TestdataEntity();
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataValue> valueRange() {
+        // two values needed to allow for at least one doable move, otherwise the second step ends in an infinite loop
+        return Arrays.asList(new TestdataValue(), new TestdataValue());
+    }
+
+    @Override
+    public TestdataCorrectlyClonedSolution cloneSolution(TestdataCorrectlyClonedSolution original) {
+        TestdataCorrectlyClonedSolution clone = new TestdataCorrectlyClonedSolution();
+        clone.entity.setValue(original.entity.getValue());
+        if (original.score != null) {
+            clone.score = SimpleScore.valueOf(original.score.getInitScore(), original.score.getScore());
+        }
+        return clone;
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataEntitiesNotClonedSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataEntitiesNotClonedSolution.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.testdata.domain.customcloner;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.cloner.SolutionCloner;
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+
+@PlanningSolution(solutionCloner = TestdataEntitiesNotClonedSolution.class)
+public class TestdataEntitiesNotClonedSolution implements SolutionCloner<TestdataEntitiesNotClonedSolution> {
+
+    @PlanningScore
+    private SimpleScore score;
+    @PlanningEntityProperty
+    private TestdataEntity entity = new TestdataEntity();
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataValue> valueRange() {
+        // solver will never get to this point due to cloning corruption
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public TestdataEntitiesNotClonedSolution cloneSolution(TestdataEntitiesNotClonedSolution original) {
+        TestdataEntitiesNotClonedSolution clone = new TestdataEntitiesNotClonedSolution();
+        clone.entity = original.entity;
+        if (original.score != null) {
+            clone.score = SimpleScore.valueOf(original.score.getInitScore(), original.score.getScore());
+        }
+        return clone;
+    }
+
+}

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataScoreNotEqualSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataScoreNotEqualSolution.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.testdata.domain.customcloner;
+
+import java.util.List;
+
+import org.optaplanner.core.api.domain.solution.PlanningEntityProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.domain.solution.cloner.SolutionCloner;
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProperty;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
+import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
+import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+
+@PlanningSolution(solutionCloner = TestdataScoreNotEqualSolution.class)
+public class TestdataScoreNotEqualSolution implements SolutionCloner<TestdataScoreNotEqualSolution> {
+
+    @PlanningScore
+    private SimpleScore score;
+    @PlanningEntityProperty
+    private TestdataEntity entity = new TestdataEntity();
+
+    @ValueRangeProvider(id = "valueRange")
+    @ProblemFactCollectionProperty
+    public List<TestdataValue> valueRange() {
+        // solver will never get to this point due to cloning corruption
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public TestdataScoreNotEqualSolution cloneSolution(TestdataScoreNotEqualSolution original) {
+        TestdataScoreNotEqualSolution clone = new TestdataScoreNotEqualSolution();
+        clone.entity.setValue(original.entity.getValue());
+        if (original.score != null) {
+            clone.score = SimpleScore.valueOf(original.score.getInitScore() - 1, original.score.getScore() - 1);
+        } else {
+            clone.score = SimpleScore.valueOfInitialized(0);
+        }
+        if (clone.score.equals(original.score)) {
+            throw new IllegalStateException("The cloned score should be intentionally inequal to the original score");
+        }
+        return clone;
+    }
+
+}


### PR DESCRIPTION
While I was refactoring some tests due to the removal of `PlanningCloneable` I came across an old TODO to increase test coverage for the detection of corrupted cloning (c55f3c8980) that was implemented in [BZ-1139670](https://bugzilla.redhat.com/show_bug.cgi?id=1139670). So I resolved it.

Note for QE: when this is merged, remove `CustomSolutionClonerTest#testBadCustomSolutionCloner`.