### PR TITLE
TestGen fixes 2

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/score/director/ScoreDirectorFactoryConfig.java
@@ -450,7 +450,7 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
                         + kieBaseConfigurationProperties + ") must be null.");
             }
             if (BooleanUtils.isTrue(generateDroolsTestOnError)) {
-                return new TestGenLegacyDroolsScoreDirectorFactory<>(kieBase);
+                return new TestGenLegacyDroolsScoreDirectorFactory<>(kieBase, null, null);
             } else {
                 return new LegacyDroolsScoreDirectorFactory<>(kieBase);
             }
@@ -510,7 +510,7 @@ public class ScoreDirectorFactoryConfig extends AbstractConfig<ScoreDirectorFact
             }
             KieBase kieBase = kieContainer.newKieBase(kieBaseConfiguration);
             if (BooleanUtils.isTrue(generateDroolsTestOnError)) {
-                return new TestGenLegacyDroolsScoreDirectorFactory<>(kieBase);
+                return new TestGenLegacyDroolsScoreDirectorFactory<>(kieBase, scoreDrlList, scoreDrlFileList);
             } else {
                 return new LegacyDroolsScoreDirectorFactory<>(kieBase);
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenDroolsScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenDroolsScoreDirector.java
@@ -103,7 +103,7 @@ public class TestGenDroolsScoreDirector<Solution_> extends DroolsScoreDirector<S
                 minJournal.replay(createKieSession());
                 throw new IllegalStateException();
             } catch (TestGenCorruptedScoreException tgcse) {
-                writer.setScore(tgcse.getUncorruptedScore());
+                writer.setCorruptedScoreException(tgcse);
             }
             writer.print(minJournal, testFile);
             throw wrapOriginalException(e);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenDroolsScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenDroolsScoreDirector.java
@@ -17,6 +17,7 @@ package org.optaplanner.core.impl.score.director.drools.testgen;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.List;
 
 import org.kie.api.runtime.KieSession;
 import org.optaplanner.core.api.score.Score;
@@ -35,10 +36,19 @@ public class TestGenDroolsScoreDirector<Solution_> extends DroolsScoreDirector<S
 
     private final TestGenKieSessionJournal journal = new TestGenKieSessionJournal();
     private final File testFile = new File("DroolsReproducerTest.java");
+    private final TestGenTestWriter writer = new TestGenTestWriter();
 
-    public TestGenDroolsScoreDirector(DroolsScoreDirectorFactory<Solution_> scoreDirectorFactory,
-            boolean locatorEnabled, boolean constraintMatchEnabledPreference) {
+    public TestGenDroolsScoreDirector(
+            DroolsScoreDirectorFactory<Solution_> scoreDirectorFactory,
+            boolean locatorEnabled,
+            boolean constraintMatchEnabledPreference,
+            List<String> scoreDrlList,
+            List<File> scoreDrlFileList) {
         super(scoreDirectorFactory, locatorEnabled, constraintMatchEnabledPreference);
+        writer.setScoreDefinition(scoreDirectorFactory.getScoreDefinition());
+        writer.setConstraintMatchEnabled(constraintMatchEnabledPreference);
+        writer.setScoreDrlList(scoreDrlList);
+        writer.setScoreDrlFileList(scoreDrlFileList);
     }
 
     public KieSession createKieSession() {
@@ -75,7 +85,7 @@ public class TestGenDroolsScoreDirector<Solution_> extends DroolsScoreDirector<S
             // TODO check the exception is coming from org.drools
             TestGenDroolsExceptionReproducer reproducer = new TestGenDroolsExceptionReproducer(e, this);
             TestGenKieSessionJournal minJournal = TestGenerator.minimize(journal, reproducer);
-            TestGenTestWriter.print(minJournal, testFile);
+            writer.print(minJournal, testFile);
             throw wrapOriginalException(e);
         }
     }
@@ -89,18 +99,13 @@ public class TestGenDroolsScoreDirector<Solution_> extends DroolsScoreDirector<S
             // TODO check it's really corrupted score
             TestGenCorruptedScoreReproducer reproducer = new TestGenCorruptedScoreReproducer(e.getMessage(), this);
             TestGenKieSessionJournal minJournal = TestGenerator.minimize(journal, reproducer);
-            Score<?> uncorruptedScore = workingScore;
             try {
                 minJournal.replay(createKieSession());
+                throw new IllegalStateException();
             } catch (TestGenCorruptedScoreException tgcse) {
-                uncorruptedScore = tgcse.getUncorruptedScore();
+                writer.setScore(tgcse.getUncorruptedScore());
             }
-            TestGenTestWriter.printWithScoreAssert(
-                    minJournal,
-                    getScoreDefinition().getClass(),
-                    constraintMatchEnabledPreference,
-                    uncorruptedScore.toString(),
-                    testFile);
+            writer.print(minJournal, testFile);
             throw wrapOriginalException(e);
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenDroolsScoreDirectorFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenDroolsScoreDirectorFactory.java
@@ -28,7 +28,7 @@ public class TestGenDroolsScoreDirectorFactory<Solution_> extends DroolsScoreDir
     @Override
     public DroolsScoreDirector<Solution_> buildScoreDirector(
             boolean locatorEnabled, boolean constraintMatchEnabledPreference) {
-        return new TestGenDroolsScoreDirector<>(this, locatorEnabled, constraintMatchEnabledPreference);
+        return new TestGenDroolsScoreDirector<>(this, locatorEnabled, constraintMatchEnabledPreference, null, null);
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenLegacyDroolsScoreDirectorFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenLegacyDroolsScoreDirectorFactory.java
@@ -15,20 +15,29 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen;
 
+import java.io.File;
+import java.util.List;
+
 import org.kie.api.KieBase;
 import org.optaplanner.core.impl.score.director.drools.DroolsScoreDirector;
 import org.optaplanner.core.impl.score.director.drools.LegacyDroolsScoreDirectorFactory;
 
 public class TestGenLegacyDroolsScoreDirectorFactory<Solution_> extends LegacyDroolsScoreDirectorFactory<Solution_> {
 
-    public TestGenLegacyDroolsScoreDirectorFactory(KieBase kieBase) {
+    private final List<String> scoreDrlList;
+    private final List<File> scoreDrlFileList;
+
+    public TestGenLegacyDroolsScoreDirectorFactory(KieBase kieBase, List<String> scoreDrlList, List<File> scoreDrlFileList) {
         super(kieBase);
+        this.scoreDrlList = scoreDrlList;
+        this.scoreDrlFileList = scoreDrlFileList;
     }
 
     @Override
     public DroolsScoreDirector<Solution_> buildScoreDirector(
             boolean locatorEnabled, boolean constraintMatchEnabledPreference) {
-        return new TestGenDroolsScoreDirector<>(this, locatorEnabled, constraintMatchEnabledPreference);
+        return new TestGenDroolsScoreDirector<>(
+                this, locatorEnabled, constraintMatchEnabledPreference, scoreDrlList, scoreDrlFileList);
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenTestWriter.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenTestWriter.java
@@ -21,11 +21,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
-import java.lang.annotation.Annotation;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import org.optaplanner.core.api.domain.entity.PlanningEntity;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.holder.ScoreHolder;
 import org.optaplanner.core.impl.score.director.drools.DroolsScoreDirector;
@@ -76,25 +74,8 @@ class TestGenTestWriter {
     }
 
     private void printInit() {
-        String domainPackage = null;
-        for (TestGenFact fact : journal.getFacts()) {
-            Class<? extends Object> factClass = fact.getInstance().getClass();
-            for (Annotation ann : factClass.getAnnotations()) {
-                if (PlanningEntity.class.equals(ann.annotationType())) {
-                    domainPackage = factClass.getPackage().getName();
-                }
-                break;
-            }
-            if (domainPackage != null) {
-                break;
-            }
-        }
-
-        if (domainPackage == null) {
-            throw new IllegalStateException("Cannot determine planning domain package.");
-        }
-
-        sb.append(String.format("package %s;%n%n", domainPackage));
+        sb.append("package org.optaplanner.testgen;").append(System.lineSeparator())
+                .append(System.lineSeparator());
         SortedSet<String> imports = new TreeSet<>();
         imports.add("org.junit.Before");
         imports.add("org.junit.Test");
@@ -113,7 +94,7 @@ class TestGenTestWriter {
         for (TestGenFact fact : journal.getFacts()) {
             for (Class<?> cls : fact.getImports()) {
                 String pkgName = cls.getPackage().getName();
-                if (!pkgName.equals(domainPackage) && !pkgName.equals("java.lang")) {
+                if (!pkgName.equals("java.lang")) {
                     imports.add(cls.getCanonicalName());
                 }
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenTestWriter.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenTestWriter.java
@@ -70,7 +70,6 @@ class TestGenTestWriter {
         }
         if (scoreDefinition != null) {
             imports.add("org.junit.Assert");
-            imports.add(Score.class.getCanonicalName());
             imports.add(ScoreHolder.class.getCanonicalName());
             imports.add(scoreDefinition.getClass().getCanonicalName());
         }
@@ -90,6 +89,15 @@ class TestGenTestWriter {
                 .append("public class DroolsReproducerTest {").append(System.lineSeparator())
                 .append(System.lineSeparator())
                 .append("    KieSession kieSession;").append(System.lineSeparator());
+        if (scoreDefinition != null) {
+            sb
+                    .append("    ScoreHolder scoreHolder = new ")
+                    .append(scoreDefinition.getClass().getSimpleName())
+                    .append("().buildScoreHolder(")
+                    .append(constraintMatchEnabled)
+                    .append(");").append(System.lineSeparator());
+        }
+
         for (TestGenFact fact : journal.getFacts()) {
             fact.printInitialization(sb);
         }
@@ -121,8 +129,7 @@ class TestGenTestWriter {
                 .append(System.lineSeparator());
         if (scoreDefinition != null) {
             sb.append("        kieSession.setGlobal(\"").append(DroolsScoreDirector.GLOBAL_SCORE_HOLDER_KEY)
-                    .append("\", new ").append(scoreDefinition.getClass().getSimpleName()).append("().buildScoreHolder(")
-                    .append(constraintMatchEnabled).append("));")
+                    .append("\", scoreHolder);")
                     .append(System.lineSeparator())
                     .append(System.lineSeparator());
         }
@@ -146,10 +153,7 @@ class TestGenTestWriter {
             op.print(sb);
         }
         if (scoreDefinition != null) {
-            sb.append("        Score<?> score = ((ScoreHolder) kieSession.getGlobal(\"")
-                    .append(DroolsScoreDirector.GLOBAL_SCORE_HOLDER_KEY).append("\")).extractScore(0);")
-                    .append(System.lineSeparator());
-            sb.append("        Assert.assertEquals(\"").append(score).append("\", score.toString());")
+            sb.append("        Assert.assertEquals(\"").append(score).append("\", scoreHolder.extractScore(0).toString());")
                     .append(System.lineSeparator());
         }
         sb

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenerator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenerator.java
@@ -130,7 +130,7 @@ final class TestGenerator {
                 addWithDependencies(f, minimal);
             }
         }
-        journal = new TestGenKieSessionJournal(minimal, journal.getInitialInserts(), journal.getMoveOperations());
+        journal.getFacts().retainAll(minimal);
         logger.info("{} facts remaining.", journal.getFacts().size());
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenerator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenerator.java
@@ -56,6 +56,7 @@ final class TestGenerator {
         pruneInserts();
         pruneFacts();
         pruneSetup();
+        pruneFacts();
         assertOriginalExceptionReproduced("Cannot reproduce the original problem after pruning the journal. "
                 + "This is a bug!");
         return journal;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenAbstractValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenAbstractValueProvider.java
@@ -37,6 +37,11 @@ abstract class TestGenAbstractValueProvider<T> implements TestGenValueProvider<T
     }
 
     @Override
+    public List<Class<?>> getImports() {
+        return Collections.emptyList();
+    }
+
+    @Override
     public List<TestGenFact> getRequiredFacts() {
         return Collections.emptyList();
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenAbstractValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenAbstractValueProvider.java
@@ -15,6 +15,9 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
+import java.util.Collections;
+import java.util.List;
+
 abstract class TestGenAbstractValueProvider<T> implements TestGenValueProvider<T> {
 
     protected final T value;
@@ -31,6 +34,11 @@ abstract class TestGenAbstractValueProvider<T> implements TestGenValueProvider<T
     @Override
     public T getUninitialized() {
         return null;
+    }
+
+    @Override
+    public List<TestGenFact> getRequiredFacts() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenAbstractValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenAbstractValueProvider.java
@@ -29,6 +29,11 @@ abstract class TestGenAbstractValueProvider<T> implements TestGenValueProvider<T
     }
 
     @Override
+    public T getUninitialized() {
+        return null;
+    }
+
+    @Override
     public void printSetup(StringBuilder sb) {
         // no setup required
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenEnumValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenEnumValueProvider.java
@@ -15,10 +15,18 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
+import java.util.Collections;
+import java.util.List;
+
 class TestGenEnumValueProvider extends TestGenAbstractValueProvider<Enum<?>> {
 
     public TestGenEnumValueProvider(Enum<?> value) {
         super(value);
+    }
+
+    @Override
+    public List<Class<?>> getImports() {
+        return Collections.singletonList(value.getClass());
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenExistingInstanceValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenExistingInstanceValueProvider.java
@@ -15,13 +15,23 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
+import java.util.Collections;
+import java.util.List;
+
 class TestGenExistingInstanceValueProvider extends TestGenAbstractValueProvider<Object> {
 
     private final String identifier;
+    private List<TestGenFact> facts;
 
-    public TestGenExistingInstanceValueProvider(Object value, String identifier) {
+    public TestGenExistingInstanceValueProvider(Object value, String identifier, TestGenFact fact) {
         super(value);
         this.identifier = identifier;
+        this.facts = Collections.singletonList(fact);
+    }
+
+    @Override
+    public List<TestGenFact> getRequiredFacts() {
+        return facts;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenFact.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenFact.java
@@ -22,16 +22,18 @@ public interface TestGenFact {
 
     void setUp(Map<Object, TestGenFact> existingInstances);
 
-    List<TestGenFact> getDependencies();
-
-    List<Class<?>> getImports();
-
     void reset();
 
     void printInitialization(StringBuilder sb);
 
     void printSetup(StringBuilder sb);
 
-    public Object getInstance();
+    Object getInstance();
+
+    List<TestGenFactField> getFields();
+
+    List<TestGenFact> getDependencies();
+
+    List<Class<?>> getImports();
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenFactField.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenFactField.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.score.director.drools.testgen.fact;
+
+import java.lang.reflect.Method;
+
+import org.optaplanner.core.impl.domain.common.ReflectionHelper;
+import org.optaplanner.core.impl.domain.common.accessor.BeanPropertyMemberAccessor;
+
+public class TestGenFactField {
+
+    private final TestGenValueFact fact;
+    private final BeanPropertyMemberAccessor accessor;
+    private final TestGenValueProvider<?> valueProvider;
+    private boolean active = true;
+
+    TestGenFactField(TestGenValueFact fact, BeanPropertyMemberAccessor accessor, TestGenValueProvider<?> valueProvider) {
+        this.fact = fact;
+        this.accessor = accessor;
+        this.valueProvider = valueProvider;
+    }
+
+    void reset() {
+        Object value = active ? valueProvider.get() : valueProvider.getUninitialized();
+        accessor.executeSetter(fact.getInstance(), value);
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    void print(StringBuilder sb) {
+        if (active) {
+            Method setter = ReflectionHelper.getSetterMethod(
+                    fact.getInstance().getClass(), accessor.getType(), accessor.getName());
+            valueProvider.printSetup(sb);
+            // null original value means the field is uninitialized so there's no need to .set(null);
+            if (valueProvider.get() != null) {
+                sb.append(String.format("        %s.%s(%s);%n",
+                        fact.getVariableName(), setter.getName(), valueProvider.toString()));
+            }
+        }
+    }
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenFactField.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenFactField.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Method;
 import org.optaplanner.core.impl.domain.common.ReflectionHelper;
 import org.optaplanner.core.impl.domain.common.accessor.BeanPropertyMemberAccessor;
 
-public class TestGenFactField {
+public class TestGenFactField implements Comparable<TestGenFactField> {
 
     private final TestGenValueFact fact;
     private final BeanPropertyMemberAccessor accessor;
@@ -58,4 +58,10 @@ public class TestGenFactField {
             }
         }
     }
+
+    @Override
+    public int compareTo(TestGenFactField o) {
+        return accessor.getName().compareTo(o.accessor.getName());
+    }
+
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenFactField.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenFactField.java
@@ -16,6 +16,7 @@
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 import org.optaplanner.core.impl.domain.common.ReflectionHelper;
 import org.optaplanner.core.impl.domain.common.accessor.BeanPropertyMemberAccessor;
@@ -36,6 +37,10 @@ public class TestGenFactField implements Comparable<TestGenFactField> {
     void reset() {
         Object value = active ? valueProvider.get() : valueProvider.getUninitialized();
         accessor.executeSetter(fact.getInstance(), value);
+    }
+
+    public List<TestGenFact> getRequiredFacts() {
+        return valueProvider.getRequiredFacts();
     }
 
     public boolean isActive() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenFactField.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenFactField.java
@@ -39,6 +39,10 @@ public class TestGenFactField implements Comparable<TestGenFactField> {
         accessor.executeSetter(fact.getInstance(), value);
     }
 
+    public List<Class<?>> getImports() {
+        return valueProvider.getImports();
+    }
+
     public List<TestGenFact> getRequiredFacts() {
         return valueProvider.getRequiredFacts();
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenListValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenListValueProvider.java
@@ -19,6 +19,8 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 class TestGenListValueProvider extends TestGenAbstractValueProvider<List<?>> {
 
@@ -26,26 +28,25 @@ class TestGenListValueProvider extends TestGenAbstractValueProvider<List<?>> {
     private final Type typeArgument;
     private final Map<Object, TestGenFact> existingInstances;
     private final List<Class<?>> imports = new ArrayList<>();
+    private final List<TestGenFact> requiredFacts;
 
-    public TestGenListValueProvider(List<?> value, String identifier, Type genericType, Map<Object, TestGenFact> existingInstances) {
+    public TestGenListValueProvider(List<?> value, String identifier, Type genericType,
+            Map<Object, TestGenFact> existingInstances) {
         super(value);
         this.identifier = identifier;
         this.typeArgument = genericType;
         this.existingInstances = existingInstances;
         imports.add(ArrayList.class);
         imports.add((Class<?>) genericType);
+        requiredFacts = value.stream()
+                .map(i -> existingInstances.get(i))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     @Override
     public List<TestGenFact> getRequiredFacts() {
-        ArrayList<TestGenFact> facts = new ArrayList<>();
-        for (Object o : value) {
-            TestGenFact fact = existingInstances.get(o);
-            if (fact != null) {
-                facts.add(fact);
-            }
-        }
-        return facts;
+        return requiredFacts;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenListValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenListValueProvider.java
@@ -48,6 +48,7 @@ class TestGenListValueProvider extends TestGenAbstractValueProvider<List<?>> {
         return facts;
     }
 
+    @Override
     public List<Class<?>> getImports() {
         return imports;
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenListValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenListValueProvider.java
@@ -36,7 +36,8 @@ class TestGenListValueProvider extends TestGenAbstractValueProvider<List<?>> {
         imports.add((Class<?>) genericType);
     }
 
-    public List<TestGenFact> getFacts() {
+    @Override
+    public List<TestGenFact> getRequiredFacts() {
         ArrayList<TestGenFact> facts = new ArrayList<>();
         for (Object o : value) {
             TestGenFact fact = existingInstances.get(o);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenMapValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenMapValueProvider.java
@@ -39,7 +39,8 @@ class TestGenMapValueProvider extends TestGenAbstractValueProvider<Map<?, ?>> {
         imports.add((Class<?>) typeArguments[1]);
     }
 
-    public List<TestGenFact> getFacts() {
+    @Override
+    public List<TestGenFact> getRequiredFacts() {
         ArrayList<TestGenFact> facts = new ArrayList<>();
         for (Map.Entry<? extends Object, ? extends Object> entry : value.entrySet()) {
             addFact(facts, entry.getKey());

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenMapValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenMapValueProvider.java
@@ -49,6 +49,7 @@ class TestGenMapValueProvider extends TestGenAbstractValueProvider<Map<?, ?>> {
         return facts;
     }
 
+    @Override
     public List<Class<?>> getImports() {
         return imports;
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenNullFact.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenNullFact.java
@@ -26,6 +26,11 @@ public class TestGenNullFact implements TestGenFact {
     }
 
     @Override
+    public List<TestGenFactField> getFields() {
+        return Collections.emptyList();
+    }
+
+    @Override
     public List<TestGenFact> getDependencies() {
         return Collections.emptyList();
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenParsedValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenParsedValueProvider.java
@@ -16,6 +16,8 @@
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
 
 class TestGenParsedValueProvider extends TestGenAbstractValueProvider<Object> {
 
@@ -24,6 +26,11 @@ class TestGenParsedValueProvider extends TestGenAbstractValueProvider<Object> {
     public TestGenParsedValueProvider(Method parseMethod, Object value) {
         super(value);
         this.parseMethod = parseMethod;
+    }
+
+    @Override
+    public List<Class<?>> getImports() {
+        return Collections.singletonList(value.getClass());
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenPrimitiveValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenPrimitiveValueProvider.java
@@ -17,8 +17,42 @@ package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
 class TestGenPrimitiveValueProvider extends TestGenAbstractValueProvider<Object> {
 
+    private byte defBy;
+    private short defS;
+    private int defI;
+    private long defL;
+    private float defF;
+    private double defD;
+    private boolean defBo;
+    private char defC;
+    private final Object uninitialized;
+
     public TestGenPrimitiveValueProvider(Object value) {
         super(value);
+        if (value.getClass().equals(Byte.class)) {
+            uninitialized = defBy;
+        } else if (value.getClass().equals(Short.class)) {
+            uninitialized = defS;
+        } else if (value.getClass().equals(Integer.class)) {
+            uninitialized = defI;
+        } else if (value.getClass().equals(Long.class)) {
+            uninitialized = defL;
+        } else if (value.getClass().equals(Float.class)) {
+            uninitialized = defF;
+        } else if (value.getClass().equals(Double.class)) {
+            uninitialized = defD;
+        } else if (value.getClass().equals(Boolean.class)) {
+            uninitialized = defBo;
+        } else if (value.getClass().equals(Character.class)) {
+            uninitialized = defC;
+        } else {
+            throw new IllegalStateException("Unsupported type: " + value.getClass().getCanonicalName());
+        }
+    }
+
+    @Override
+    public Object getUninitialized() {
+        return uninitialized;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenSetValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenSetValueProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.score.director.drools.testgen.fact;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class TestGenSetValueProvider extends TestGenAbstractValueProvider<Set<?>> {
+
+    private final String identifier;
+    private final Type typeArgument;
+    private final Map<Object, TestGenFact> existingInstances;
+    private final List<Class<?>> imports = new ArrayList<>();
+    private final List<TestGenFact> requiredFacts;
+
+    public TestGenSetValueProvider(Set<?> value, String identifier, Type genericType,
+            Map<Object, TestGenFact> existingInstances) {
+        super(value);
+        this.identifier = identifier;
+        this.typeArgument = genericType;
+        this.existingInstances = existingInstances;
+        imports.add(HashSet.class);
+        imports.add((Class<?>) genericType);
+        requiredFacts = value.stream()
+                .map(i -> existingInstances.get(i))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<TestGenFact> getRequiredFacts() {
+        return requiredFacts;
+    }
+
+    @Override
+    public List<Class<?>> getImports() {
+        return imports;
+    }
+
+    @Override
+    public void printSetup(StringBuilder sb) {
+        String e = ((Class<?>) typeArgument).getSimpleName();
+        sb.append(String.format("        HashSet<%s> %s = new HashSet<%s>();%n", e, identifier, e));
+        for (Object item : value) {
+            sb.append(String.format("        //%s%n", item));
+            sb.append(String.format("        %s.add(%s);%n", identifier, existingInstances.get(item)));
+        }
+    }
+
+    @Override
+    public String toString() {
+        return identifier;
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
@@ -31,6 +31,7 @@ import org.optaplanner.core.impl.domain.common.accessor.BeanPropertyMemberAccess
 public class TestGenValueFact implements TestGenFact {
 
     private final Object instance;
+    private final String instanceToString;
     private final String variableName;
     private final List<TestGenFactField> fields = new ArrayList<>();
     private final List<TestGenFact> dependencies = new ArrayList<>();
@@ -38,6 +39,7 @@ public class TestGenValueFact implements TestGenFact {
 
     public TestGenValueFact(int id, Object instance) {
         this.instance = instance;
+        this.instanceToString = instance.toString();
         this.variableName = instance.getClass().getSimpleName().substring(0, 1).toLowerCase()
                 + instance.getClass().getSimpleName().substring(1) + "_" + id;
     }
@@ -162,7 +164,7 @@ public class TestGenValueFact implements TestGenFact {
 
     @Override
     public void printSetup(StringBuilder sb) {
-        sb.append(String.format("        //%s%n", instance));
+        sb.append(String.format("        //%s%n", instanceToString));
         fields.forEach(f -> f.print(sb));
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
@@ -139,10 +139,10 @@ public class TestGenValueFact implements TestGenFact {
     @Override
     public void printInitialization(StringBuilder sb) {
         if (instance.getClass().isEnum()) {
-            sb.append(String.format("    %s %s = %s.%s;%n",
+            sb.append(String.format("    private final %s %s = %s.%s;%n",
                     instance.getClass().getSimpleName(), variableName, instance.getClass().getSimpleName(), ((Enum) instance).name()));
         } else {
-            sb.append(String.format("    %s %s = new %s();%n",
+            sb.append(String.format("    private final %s %s = new %s();%n",
                     instance.getClass().getSimpleName(), variableName, instance.getClass().getSimpleName()));
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
@@ -138,8 +138,13 @@ public class TestGenValueFact implements TestGenFact {
 
     @Override
     public void printInitialization(StringBuilder sb) {
-        sb.append(String.format("    %s %s = new %s();%n",
-                instance.getClass().getSimpleName(), variableName, instance.getClass().getSimpleName()));
+        if (instance.getClass().isEnum()) {
+            sb.append(String.format("    %s %s = %s.%s;%n",
+                    instance.getClass().getSimpleName(), variableName, instance.getClass().getSimpleName(), ((Enum) instance).name()));
+        } else {
+            sb.append(String.format("    %s %s = new %s();%n",
+                    instance.getClass().getSimpleName(), variableName, instance.getClass().getSimpleName()));
+        }
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
@@ -73,23 +73,27 @@ public class TestGenValueFact implements TestGenFact {
                     fields.add(new TestGenFactField(this, accessor, new TestGenEnumValueProvider((Enum) value)));
                 } else if (existingInstances.containsKey(value)) {
                     String id = existingInstances.get(value).toString();
-                    TestGenExistingInstanceValueProvider instanceProvider = new TestGenExistingInstanceValueProvider(value, id, existingInstances.get(value));
+                    TestGenExistingInstanceValueProvider instanceProvider = new TestGenExistingInstanceValueProvider(
+                            value, id, existingInstances.get(value));
                     fields.add(new TestGenFactField(this, accessor, instanceProvider));
                 } else if (field.getType().equals(List.class)) {
                     String id = variableName + "_" + field.getName();
                     Type[] typeArgs = ((ParameterizedType) field.getGenericType()).getActualTypeArguments();
-                    TestGenListValueProvider listValueProvider = new TestGenListValueProvider((List) value, id, typeArgs[0], existingInstances);
+                    TestGenListValueProvider listValueProvider = new TestGenListValueProvider(
+                            (List) value, id, typeArgs[0], existingInstances);
                     fields.add(new TestGenFactField(this, accessor, listValueProvider));
-                } else if (field.getType().equals(Map.class)) {
-                    String id = variableName + "_" + field.getName();
-                    Type[] typeArgs = ((ParameterizedType) field.getGenericType()).getActualTypeArguments();
-                    TestGenMapValueProvider mapValueProvider = new TestGenMapValueProvider((Map) value, id, typeArgs, existingInstances);
-                    fields.add(new TestGenFactField(this, accessor, mapValueProvider));
                 } else if (field.getType().equals(Set.class)) {
                     String id = variableName + "_" + field.getName();
                     Type[] typeArgs = ((ParameterizedType) field.getGenericType()).getActualTypeArguments();
-                    // TODO provider
-                    //fields.add(new TestGenFactField(this, accessor, setValueProvider));
+                    TestGenSetValueProvider setValueProvider = new TestGenSetValueProvider(
+                            (Set) value, id, typeArgs[0], existingInstances);
+                    fields.add(new TestGenFactField(this, accessor, setValueProvider));
+                } else if (field.getType().equals(Map.class)) {
+                    String id = variableName + "_" + field.getName();
+                    Type[] typeArgs = ((ParameterizedType) field.getGenericType()).getActualTypeArguments();
+                    TestGenMapValueProvider mapValueProvider = new TestGenMapValueProvider(
+                            (Map) value, id, typeArgs, existingInstances);
+                    fields.add(new TestGenFactField(this, accessor, mapValueProvider));
                 } else {
                     Method parseMethod = getParseMethod(field);
                     if (parseMethod != null) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.optaplanner.core.impl.domain.common.ReflectionHelper;
@@ -84,6 +85,11 @@ public class TestGenValueFact implements TestGenFact {
                     Type[] typeArgs = ((ParameterizedType) field.getGenericType()).getActualTypeArguments();
                     TestGenMapValueProvider mapValueProvider = new TestGenMapValueProvider((Map) value, id, typeArgs, existingInstances);
                     fields.add(new TestGenFactField(this, accessor, mapValueProvider));
+                } else if (field.getType().equals(Set.class)) {
+                    String id = variableName + "_" + field.getName();
+                    Type[] typeArgs = ((ParameterizedType) field.getGenericType()).getActualTypeArguments();
+                    // TODO provider
+                    //fields.add(new TestGenFactField(this, accessor, setValueProvider));
                 } else {
                     Method parseMethod = getParseMethod(field);
                     if (parseMethod != null) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -43,6 +44,7 @@ public class TestGenValueFact implements TestGenFact {
 
     @Override
     public void setUp(Map<Object, TestGenFact> existingInstances) {
+        fields.clear();
         dependencies.clear();
         imports.clear();
         imports.add(instance.getClass());
@@ -53,6 +55,7 @@ public class TestGenValueFact implements TestGenFact {
             }
             clazz = clazz.getSuperclass();
         }
+        Collections.sort(fields);
     }
 
     private void setUpField(Field field, Map<Object, TestGenFact> existingInstances) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueProvider.java
@@ -15,11 +15,15 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
+import java.util.List;
+
 interface TestGenValueProvider<T> {
 
     T get();
 
     T getUninitialized();
+
+    List<TestGenFact> getRequiredFacts();
 
     void printSetup(StringBuilder sb);
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueProvider.java
@@ -23,6 +23,8 @@ interface TestGenValueProvider<T> {
 
     T getUninitialized();
 
+    List<Class<?>> getImports();
+
     List<TestGenFact> getRequiredFacts();
 
     void printSetup(StringBuilder sb);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueProvider.java
@@ -19,6 +19,8 @@ interface TestGenValueProvider<T> {
 
     T get();
 
+    T getUninitialized();
+
     void printSetup(StringBuilder sb);
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreReproducer.java
@@ -61,6 +61,9 @@ public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemRe
             if (e.getMessage() != null && e.getMessage().startsWith("No fact handle for ")) {
                 // this is common when removing insert of a fact that is later updated - not interesting
                 logger.debug("    Can't remove insert: {}: {}", e.getClass().getSimpleName(), e.getMessage());
+            } else if (e.getMessage() != null && e.getMessage().startsWith("Error evaluating constraint '")) {
+                // this is common after pruning setup code, which can lead to NPE during rule evaluation
+                logger.debug("    Can't drop field setup: {}: {}", e.getClass().getSimpleName(), e.getMessage());
             } else {
                 logger.info("Unexpected exception", e);
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreReproducer.java
@@ -60,10 +60,10 @@ public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemRe
         } catch (RuntimeException e) {
             if (e.getMessage() != null && e.getMessage().startsWith("No fact handle for ")) {
                 // this is common when removing insert of a fact that is later updated - not interesting
-                logger.debug("    Can't remove insert: {}: {}", e.getClass().getSimpleName(), e.getMessage());
+                logger.debug("    Can't remove insert: {}", e.toString());
             } else if (e.getMessage() != null && e.getMessage().startsWith("Error evaluating constraint '")) {
                 // this is common after pruning setup code, which can lead to NPE during rule evaluation
-                logger.debug("    Can't drop field setup: {}: {}", e.getClass().getSimpleName(), e.getMessage());
+                logger.debug("    Can't drop field setup: {}", e.toString());
             } else {
                 logger.info("Unexpected exception", e);
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreReproducer.java
@@ -58,7 +58,7 @@ public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemRe
         } catch (TestGenCorruptedScoreException e) {
             return true;
         } catch (RuntimeException e) {
-            if (e.getMessage().startsWith("No fact handle for ")) {
+            if (e.getMessage() != null && e.getMessage().startsWith("No fact handle for ")) {
                 // this is common when removing insert of a fact that is later updated - not interesting
                 logger.debug("    Can't remove insert: {}: {}", e.getClass().getSimpleName(), e.getMessage());
             } else {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenDroolsExceptionReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenDroolsExceptionReproducer.java
@@ -42,7 +42,8 @@ public class TestGenDroolsExceptionReproducer implements TestGenOriginalProblemR
             if (areEqual(originalException, reproducedException)) {
                 return true;
             } else {
-                if (reproducedException.getMessage().startsWith("No fact handle for ")) {
+                if (reproducedException.getMessage() != null
+                        && reproducedException.getMessage().startsWith("No fact handle for ")) {
                     // this is common when removing insert of a fact that is later updated - not interesting
                     logger.debug("    Can't remove insert: {}", reproducedException.toString());
                 } else {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenDroolsExceptionReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenDroolsExceptionReproducer.java
@@ -49,8 +49,7 @@ public class TestGenDroolsExceptionReproducer implements TestGenOriginalProblemR
                 } else if (reproducedException.getMessage() != null
                         && reproducedException.getMessage().startsWith("Error evaluating constraint '")) {
                     // this is common after pruning setup code, which can lead to NPE during rule evaluation
-                    logger.debug("    Can't drop field setup: {}: {}",
-                            reproducedException.getClass().getSimpleName(), reproducedException.getMessage());
+                    logger.debug("    Can't drop field setup: {}", reproducedException.toString());
                 } else {
                     logger.info("Unexpected exception", reproducedException);
                 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenDroolsExceptionReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenDroolsExceptionReproducer.java
@@ -46,6 +46,11 @@ public class TestGenDroolsExceptionReproducer implements TestGenOriginalProblemR
                         && reproducedException.getMessage().startsWith("No fact handle for ")) {
                     // this is common when removing insert of a fact that is later updated - not interesting
                     logger.debug("    Can't remove insert: {}", reproducedException.toString());
+                } else if (reproducedException.getMessage() != null
+                        && reproducedException.getMessage().startsWith("Error evaluating constraint '")) {
+                    // this is common after pruning setup code, which can lead to NPE during rule evaluation
+                    logger.debug("    Can't drop field setup: {}: {}",
+                            reproducedException.getClass().getSimpleName(), reproducedException.getMessage());
                 } else {
                     logger.info("Unexpected exception", reproducedException);
                 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
@@ -15,11 +15,15 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 import org.junit.Test;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
+import org.optaplanner.core.impl.testdata.domain.collection.TestdataEntityCollectionPropertyEntity;
 
 import static org.junit.Assert.*;
 
@@ -39,7 +43,7 @@ public class TestGenValueFactTest {
     }
 
     @Test
-    public void importsAndDependencies() {
+    public void importsAndDependenciesSimple() {
         HashMap<Object, TestGenFact> instances = new HashMap<>();
         TestdataEntity entity = new TestdataEntity();
         TestGenValueFact f1 = new TestGenValueFact(0, entity);
@@ -61,7 +65,6 @@ public class TestGenValueFactTest {
         assertTrue(f2.getImports().contains(TestdataValue.class));
         assertTrue(f1.getDependencies().isEmpty());
 
-
         f1.setUp(instances);
         assertEquals(1, f1.getImports().size());
         assertTrue(f1.getImports().contains(TestdataEntity.class));
@@ -69,4 +72,64 @@ public class TestGenValueFactTest {
         assertTrue(f1.getDependencies().contains(f2));
     }
 
+    @Test
+    public void importsAndDependenciesComplex() {
+        TestdataEntityCollectionPropertyEntity a = new TestdataEntityCollectionPropertyEntity("a", null);
+        TestdataEntityCollectionPropertyEntity b = new TestdataEntityCollectionPropertyEntity("b", null);
+        TestdataEntityCollectionPropertyEntity c = new TestdataEntityCollectionPropertyEntity("c", null);
+        TestdataEntityCollectionPropertyEntity d = new TestdataEntityCollectionPropertyEntity("d", null);
+        TestdataEntityCollectionPropertyEntity e = new TestdataEntityCollectionPropertyEntity("e", null);
+        TestdataEntityCollectionPropertyEntity f = new TestdataEntityCollectionPropertyEntity("f", null);
+        TestdataEntityCollectionPropertyEntity g = new TestdataEntityCollectionPropertyEntity("g", null);
+        TestdataEntityCollectionPropertyEntity h = new TestdataEntityCollectionPropertyEntity("h", null);
+        TestdataEntityCollectionPropertyEntity i = new TestdataEntityCollectionPropertyEntity("i", null);
+        a.setEntityList(Arrays.asList(b, c));
+//        a.setEntitySet(new HashSet<>(Arrays.asList(d, e)));
+        a.setStringToEntityMap(new HashMap<>());
+        a.getStringToEntityMap().put("f", f);
+        a.getStringToEntityMap().put("g", g);
+        a.setEntityToStringMap(new HashMap<>());
+        a.getEntityToStringMap().put(h, "h");
+        a.getEntityToStringMap().put(i, "i");
+
+        TestGenValueFact fa = new TestGenValueFact(0, a);
+        TestGenValueFact fb = new TestGenValueFact(1, b);
+        TestGenValueFact fc = new TestGenValueFact(2, c);
+        TestGenValueFact fd = new TestGenValueFact(3, d);
+        TestGenValueFact fe = new TestGenValueFact(4, e);
+        TestGenValueFact ff = new TestGenValueFact(5, f);
+        TestGenValueFact fg = new TestGenValueFact(6, g);
+        TestGenValueFact fh = new TestGenValueFact(7, h);
+        TestGenValueFact fi = new TestGenValueFact(8, i);
+
+        HashMap<Object, TestGenFact> instances = new HashMap<>();
+        instances.put(a, fa);
+        instances.put(b, fb);
+        instances.put(c, fc);
+        instances.put(d, fd);
+        instances.put(e, fe);
+        instances.put(f, ff);
+        instances.put(g, fg);
+        instances.put(h, fh);
+        instances.put(i, fi);
+
+        fa.setUp(instances);
+
+        List<TestGenFact> dependencies = fa.getDependencies();
+        assertEquals(6, dependencies.size());
+        assertTrue(dependencies.contains(fb));
+        assertTrue(dependencies.contains(fc));
+//        assertTrue(dependencies.contains(fd));
+//        assertTrue(dependencies.contains(fe));
+        assertTrue(dependencies.contains(ff));
+        assertTrue(dependencies.contains(fg));
+        assertTrue(dependencies.contains(fh));
+        assertTrue(dependencies.contains(fi));
+
+        List<Class<?>> imports = fa.getImports();
+        assertTrue(imports.contains(TestdataEntityCollectionPropertyEntity.class));
+        assertTrue(imports.contains(ArrayList.class));
+        assertTrue(imports.contains(HashMap.class));
+        assertTrue(imports.contains(String.class));
+    }
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
@@ -35,7 +35,7 @@ public class TestGenValueFactTest {
 
         StringBuilder sb = new StringBuilder(100);
         fact.printInitialization(sb);
-        assertEquals("    TestdataValue testdataValue_321 = new TestdataValue();\n", sb.toString());
+        assertEquals("    private final TestdataValue testdataValue_321 = new TestdataValue();\n", sb.toString());
     }
 
     @Test

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
@@ -18,6 +18,7 @@ package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.Test;
@@ -84,7 +85,7 @@ public class TestGenValueFactTest {
         TestdataEntityCollectionPropertyEntity h = new TestdataEntityCollectionPropertyEntity("h", null);
         TestdataEntityCollectionPropertyEntity i = new TestdataEntityCollectionPropertyEntity("i", null);
         a.setEntityList(Arrays.asList(b, c));
-//        a.setEntitySet(new HashSet<>(Arrays.asList(d, e)));
+        a.setEntitySet(new HashSet<>(Arrays.asList(d, e)));
         a.setStringToEntityMap(new HashMap<>());
         a.getStringToEntityMap().put("f", f);
         a.getStringToEntityMap().put("g", g);
@@ -116,11 +117,11 @@ public class TestGenValueFactTest {
         fa.setUp(instances);
 
         List<TestGenFact> dependencies = fa.getDependencies();
-        assertEquals(6, dependencies.size());
+        assertEquals(8, dependencies.size());
         assertTrue(dependencies.contains(fb));
         assertTrue(dependencies.contains(fc));
-//        assertTrue(dependencies.contains(fd));
-//        assertTrue(dependencies.contains(fe));
+        assertTrue(dependencies.contains(fd));
+        assertTrue(dependencies.contains(fe));
         assertTrue(dependencies.contains(ff));
         assertTrue(dependencies.contains(fg));
         assertTrue(dependencies.contains(fh));
@@ -129,6 +130,7 @@ public class TestGenValueFactTest {
         List<Class<?>> imports = fa.getImports();
         assertTrue(imports.contains(TestdataEntityCollectionPropertyEntity.class));
         assertTrue(imports.contains(ArrayList.class));
+        assertTrue(imports.contains(HashSet.class));
         assertTrue(imports.contains(HashMap.class));
         assertTrue(imports.contains(String.class));
     }


### PR DESCRIPTION
Next round of fixes and improvements, this time based on the isolation work on DROOLS-1326 and adding reproducers for DROOLS-1174 and DROOLS-1187.

* if `<scoreDrl>` is used in solver config it is now written to the reproducer
* implemented fact setup pruning -- eliminates working fact setters that are not necessary for reproducing the issue