### PR TITLE
SolutionCloner test updates

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/cloner/SolutionCloner.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/domain/solution/cloner/SolutionCloner.java
@@ -20,7 +20,7 @@ import org.optaplanner.core.api.domain.solution.PlanningSolution;
 
 /**
  * Clones a {@link PlanningSolution} during planning.
- * Used to remember the state of a good {@link PlanningSolution} so it can be recalled at a later then
+ * Used to remember the state of a good {@link PlanningSolution} so it can be recalled at a later time
  * when the original {@link PlanningSolution} is already modified.
  * Also used in population based heuristics to increase or repopulate the population.
  * <p>
@@ -36,6 +36,8 @@ public interface SolutionCloner<Solution_> {
      * <ul>
      * <li>The clone must represent the same planning problem.
      * Usually it reuses the same instances of the problem facts and problem fact collections as the {@code original}.
+     * </li>
+     * <li>The clone must have the same (equal) score as the {@code original}.
      * </li>
      * <li>The clone must use different, cloned instances of the entities and entity collections.
      * If a cloned entity changes, the original must remain unchanged.

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/domain/solution/cloner/CustomSolutionClonerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/domain/solution/cloner/CustomSolutionClonerTest.java
@@ -24,6 +24,7 @@ import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.customcloner.TestdataCorrectlyClonedSolution;
 import org.optaplanner.core.impl.testdata.domain.customcloner.TestdataEntitiesNotClonedSolution;
+import org.optaplanner.core.impl.testdata.domain.customcloner.TestdataScoreNotClonedSolution;
 import org.optaplanner.core.impl.testdata.domain.customcloner.TestdataScoreNotEqualSolution;
 import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
@@ -40,6 +41,21 @@ public class CustomSolutionClonerTest {
         solverConfig.setEnvironmentMode(EnvironmentMode.NON_INTRUSIVE_FULL_ASSERT);
 
         TestdataCorrectlyClonedSolution solution = new TestdataCorrectlyClonedSolution();
+        factory.buildSolver().solve(solution);
+    }
+
+    @Test
+    public void scoreNotCloned() {
+        // RHBRMS-1430 Possible NPE when custom cloner doesn't clone score
+        SolverFactory<TestdataScoreNotClonedSolution> factory = PlannerTestUtils.buildSolverFactory(
+                TestdataScoreNotClonedSolution.class, TestdataEntity.class);
+        SolverConfig solverConfig = factory.getSolverConfig();
+        solverConfig.setEnvironmentMode(EnvironmentMode.NON_INTRUSIVE_FULL_ASSERT);
+
+        TestdataScoreNotClonedSolution solution = new TestdataScoreNotClonedSolution();
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Cloning corruption: the original's score ");
         factory.buildSolver().solve(solution);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/domain/solution/cloner/CustomSolutionClonerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/domain/solution/cloner/CustomSolutionClonerTest.java
@@ -28,20 +28,23 @@ import org.optaplanner.core.impl.testdata.domain.customcloner.TestdataScoreNotCl
 import org.optaplanner.core.impl.testdata.domain.customcloner.TestdataScoreNotEqualSolution;
 import org.optaplanner.core.impl.testdata.util.PlannerTestUtils;
 
+import static org.junit.Assert.assertTrue;
+
 public class CustomSolutionClonerTest {
 
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
-    public void correctCloner() {
+    public void clonedUsingCustomCloner() {
         SolverFactory<TestdataCorrectlyClonedSolution> factory = PlannerTestUtils.buildSolverFactory(
                 TestdataCorrectlyClonedSolution.class, TestdataEntity.class);
         SolverConfig solverConfig = factory.getSolverConfig();
         solverConfig.setEnvironmentMode(EnvironmentMode.NON_INTRUSIVE_FULL_ASSERT);
 
         TestdataCorrectlyClonedSolution solution = new TestdataCorrectlyClonedSolution();
-        factory.buildSolver().solve(solution);
+        TestdataCorrectlyClonedSolution solved = factory.buildSolver().solve(solution);
+        assertTrue("Custom solution cloner was not used", solved.isClonedByCustomCloner());
     }
 
     @Test

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/solution/cloner/AbstractSolutionClonerTest.java
@@ -91,6 +91,7 @@ public abstract class AbstractSolutionClonerTest {
         assertNotSame(original, clone);
         assertCode("solution", clone);
         assertSame(valueList, clone.getValueList());
+        assertEquals(original.getScore(), clone.getScore());
 
         List<TestdataEntity> cloneEntityList = clone.getEntityList();
         assertNotSame(originalEntityList, cloneEntityList);
@@ -135,6 +136,7 @@ public abstract class AbstractSolutionClonerTest {
         assertNotSame(original, clone);
         assertCode("solution", clone);
         assertSame(valueList, clone.getValueList());
+        assertEquals(original.getScore(), clone.getScore());
 
         List<TestdataFieldAnnotatedEntity> cloneEntityList = clone.getEntityList();
         assertNotSame(originalEntityList, cloneEntityList);
@@ -184,6 +186,7 @@ public abstract class AbstractSolutionClonerTest {
         assertEquals(original.getFinalField(), clone.getFinalField());
         assertEquals("readHello", clone.getReadOnlyField());
         assertSame(valueList, clone.getValueList());
+        assertEquals(original.getScore(), clone.getScore());
 
         List<TestdataEntity> cloneEntityList = clone.getEntityList();
         assertNotSame(originalEntityList, cloneEntityList);
@@ -230,6 +233,7 @@ public abstract class AbstractSolutionClonerTest {
         assertCode("solution", clone);
         assertEquals("extraObjectOnSolution", clone.getExtraObject());
         assertSame(valueList, clone.getValueList());
+        assertEquals(original.getScore(), clone.getScore());
 
         List<TestdataEntity> cloneEntityList = clone.getEntityList();
         assertNotSame(originalEntityList, cloneEntityList);
@@ -280,6 +284,7 @@ public abstract class AbstractSolutionClonerTest {
         assertCode("solution", clone);
         assertEquals("extraObjectOnSolution", clone.getExtraObject());
         assertSame(valueList, clone.getValueList());
+        assertEquals(original.getScore(), clone.getScore());
 
         List<TestdataThirdPartyEntityPojo> cloneEntityList = clone.getEntityList();
         assertNotSame(originalEntityList, cloneEntityList);
@@ -351,6 +356,7 @@ public abstract class AbstractSolutionClonerTest {
         assertNotSame(original, clone);
         assertCode("solution", clone);
         assertSame(anchorList, clone.getChainedAnchorList());
+        assertEquals(original.getScore(), clone.getScore());
 
         List<TestdataChainedEntity> cloneEntityList = clone.getChainedEntityList();
         assertNotSame(originalEntityList, cloneEntityList);
@@ -407,6 +413,7 @@ public abstract class AbstractSolutionClonerTest {
         TestdataSetBasedSolution clone = cloner.cloneSolution(original);
         assertNotSame(original, clone);
         assertSame(valueSet, clone.getValueSet());
+        assertEquals(original.getScore(), clone.getScore());
 
         Set<TestdataSetBasedEntity> cloneEntitySet = clone.getEntitySet();
         assertNotSame(originalEntitySet, cloneEntitySet);
@@ -486,6 +493,7 @@ public abstract class AbstractSolutionClonerTest {
         assertNotSame(original, clone);
         assertCode("solution", clone);
         assertSame(valueList, clone.getValueList());
+        assertEquals(original.getScore(), clone.getScore());
 
         List<TestdataEntityCollectionPropertyEntity> cloneEntityList = clone.getEntityList();
         assertNotSame(originalEntityList, cloneEntityList);
@@ -578,18 +586,19 @@ public abstract class AbstractSolutionClonerTest {
         assertNotSame(original, clone);
         assertCode("solution", clone);
         assertSame(valueList, clone.getValueList());
+        assertEquals(original.getScore(), clone.getScore());
 
         List<TestdataDeepCloningEntity> cloneEntityList = clone.getEntityList();
         assertNotSame(originalEntityList, cloneEntityList);
         assertEquals(4, cloneEntityList.size());
         TestdataDeepCloningEntity cloneA = cloneEntityList.get(0);
-        assertDeepCloningEntityClone(a, cloneA, "a", "1");
+        assertDeepCloningEntityClone(a, cloneA, "a");
         TestdataDeepCloningEntity cloneB = cloneEntityList.get(1);
-        assertDeepCloningEntityClone(b, cloneB, "b", "1");
+        assertDeepCloningEntityClone(b, cloneB, "b");
         TestdataDeepCloningEntity cloneC = cloneEntityList.get(2);
-        assertDeepCloningEntityClone(c, cloneC, "c", "3");
+        assertDeepCloningEntityClone(c, cloneC, "c");
         TestdataDeepCloningEntity cloneD = cloneEntityList.get(3);
-        assertDeepCloningEntityClone(d, cloneD, "d", "3");
+        assertDeepCloningEntityClone(d, cloneD, "d");
 
         List<String> cloneGeneralShadowVariableList = clone.getGeneralShadowVariableList();
         assertNotSame(generalShadowVariableList, cloneGeneralShadowVariableList);
@@ -609,7 +618,7 @@ public abstract class AbstractSolutionClonerTest {
     }
 
     private void assertDeepCloningEntityClone(TestdataDeepCloningEntity originalEntity, TestdataDeepCloningEntity cloneEntity,
-            String entityCode, String valueCode) {
+            String entityCode) {
         assertNotSame(originalEntity, cloneEntity);
         assertCode(entityCode, originalEntity);
         assertCode(entityCode, cloneEntity);
@@ -674,18 +683,19 @@ public abstract class AbstractSolutionClonerTest {
         assertNotSame(original, clone);
         assertCode("solution", clone);
         assertSame(valueList, clone.getValueList());
+        assertEquals(original.getScore(), clone.getScore());
 
         List<TestdataFieldAnnotatedDeepCloningEntity> cloneEntityList = clone.getEntityList();
         assertNotSame(originalEntityList, cloneEntityList);
         assertEquals(4, cloneEntityList.size());
         TestdataFieldAnnotatedDeepCloningEntity cloneA = cloneEntityList.get(0);
-        assertDeepCloningEntityClone(a, cloneA, "a", "1");
+        assertDeepCloningEntityClone(a, cloneA, "a");
         TestdataFieldAnnotatedDeepCloningEntity cloneB = cloneEntityList.get(1);
-        assertDeepCloningEntityClone(b, cloneB, "b", "1");
+        assertDeepCloningEntityClone(b, cloneB, "b");
         TestdataFieldAnnotatedDeepCloningEntity cloneC = cloneEntityList.get(2);
-        assertDeepCloningEntityClone(c, cloneC, "c", "3");
+        assertDeepCloningEntityClone(c, cloneC, "c");
         TestdataFieldAnnotatedDeepCloningEntity cloneD = cloneEntityList.get(3);
-        assertDeepCloningEntityClone(d, cloneD, "d", "3");
+        assertDeepCloningEntityClone(d, cloneD, "d");
 
         List<String> cloneGeneralShadowVariableList = clone.getGeneralShadowVariableList();
         assertNotSame(generalShadowVariableList, cloneGeneralShadowVariableList);
@@ -705,7 +715,7 @@ public abstract class AbstractSolutionClonerTest {
     }
 
     private void assertDeepCloningEntityClone(TestdataFieldAnnotatedDeepCloningEntity originalEntity, TestdataFieldAnnotatedDeepCloningEntity cloneEntity,
-            String entityCode, String valueCode) {
+            String entityCode) {
         assertNotSame(originalEntity, cloneEntity);
         assertCode(entityCode, originalEntity);
         assertCode(entityCode, cloneEntity);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataCorrectlyClonedSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataCorrectlyClonedSolution.java
@@ -31,6 +31,7 @@ import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 @PlanningSolution(solutionCloner = TestdataCorrectlyClonedSolution.class)
 public class TestdataCorrectlyClonedSolution implements SolutionCloner<TestdataCorrectlyClonedSolution> {
 
+    private boolean clonedByCustomCloner = false;
     @PlanningScore
     private SimpleScore score;
     @PlanningEntityProperty
@@ -46,10 +47,15 @@ public class TestdataCorrectlyClonedSolution implements SolutionCloner<TestdataC
     @Override
     public TestdataCorrectlyClonedSolution cloneSolution(TestdataCorrectlyClonedSolution original) {
         TestdataCorrectlyClonedSolution clone = new TestdataCorrectlyClonedSolution();
-        clone.entity.setValue(original.entity.getValue());
+        clone.clonedByCustomCloner = true;
         // score is immutable so no need to create a new instance
         clone.score = original.score;
+        clone.entity.setValue(original.entity.getValue());
         return clone;
+    }
+
+    public boolean isClonedByCustomCloner() {
+        return clonedByCustomCloner;
     }
 
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataCorrectlyClonedSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataCorrectlyClonedSolution.java
@@ -47,9 +47,8 @@ public class TestdataCorrectlyClonedSolution implements SolutionCloner<TestdataC
     public TestdataCorrectlyClonedSolution cloneSolution(TestdataCorrectlyClonedSolution original) {
         TestdataCorrectlyClonedSolution clone = new TestdataCorrectlyClonedSolution();
         clone.entity.setValue(original.entity.getValue());
-        if (original.score != null) {
-            clone.score = SimpleScore.valueOf(original.score.getInitScore(), original.score.getScore());
-        }
+        // score is immutable so no need to create a new instance
+        clone.score = original.score;
         return clone;
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataScoreNotClonedSolution.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/customcloner/TestdataScoreNotClonedSolution.java
@@ -15,6 +15,7 @@
  */
 package org.optaplanner.core.impl.testdata.domain.customcloner;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.optaplanner.core.api.domain.solution.PlanningEntityProperty;
@@ -27,8 +28,8 @@ import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 
-@PlanningSolution(solutionCloner = TestdataEntitiesNotClonedSolution.class)
-public class TestdataEntitiesNotClonedSolution implements SolutionCloner<TestdataEntitiesNotClonedSolution> {
+@PlanningSolution(solutionCloner = TestdataScoreNotClonedSolution.class)
+public class TestdataScoreNotClonedSolution implements SolutionCloner<TestdataScoreNotClonedSolution> {
 
     @PlanningScore
     private SimpleScore score;
@@ -38,15 +39,13 @@ public class TestdataEntitiesNotClonedSolution implements SolutionCloner<Testdat
     @ValueRangeProvider(id = "valueRange")
     @ProblemFactCollectionProperty
     public List<TestdataValue> valueRange() {
-        // solver will never get to this point due to cloning corruption
-        throw new UnsupportedOperationException("Not supported yet.");
+        return Collections.singletonList(new TestdataValue());
     }
 
     @Override
-    public TestdataEntitiesNotClonedSolution cloneSolution(TestdataEntitiesNotClonedSolution original) {
-        TestdataEntitiesNotClonedSolution clone = new TestdataEntitiesNotClonedSolution();
-        clone.entity = original.entity;
-        clone.score = original.score;
+    public TestdataScoreNotClonedSolution cloneSolution(TestdataScoreNotClonedSolution original) {
+        TestdataScoreNotClonedSolution clone = new TestdataScoreNotClonedSolution();
+        clone.entity.setValue(original.entity.getValue());
         return clone;
     }
 


### PR DESCRIPTION
This PR contains various fixes and improvements in tests related to SolutionCloner.
* added the requirement for an equal score on the clone to SolutionCloner Javadoc
* added score equality check to AbstractSolutionClonerTest
* added test for the original fix for [RHBRMS-1430](https://issues.jboss.org/browse/RHBRMS-1430)

When this is merged, QE's CustomSolutionClonerTest can be removed completely.