### PR TITLE
Fix various Javadoc issues

### DIFF
--- a/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfig.java
+++ b/optaplanner-benchmark/src/main/java/org/optaplanner/benchmark/config/PlannerBenchmarkConfig.java
@@ -105,8 +105,8 @@ public class PlannerBenchmarkConfig {
      * Using multiple parallel benchmarks can decrease the reliability of the results.
      * <p>
      * If there aren't enough processors available, it will be decreased.
-     * @return null, a number, {@value #PARALLEL_BENCHMARK_COUNT_AUTO}
-     * or a JavaScript calculation using {@value ConfigUtils#AVAILABLE_PROCESSOR_COUNT}.
+     * @return null, a number, {@value #PARALLEL_BENCHMARK_COUNT_AUTO} or a JavaScript calculation using
+     * {@value org.optaplanner.core.config.util.ConfigUtils#AVAILABLE_PROCESSOR_COUNT}.
      */
     public String getParallelBenchmarkCount() {
         return parallelBenchmarkCount;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/Score.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/Score.java
@@ -38,7 +38,7 @@ public interface Score<S extends Score> extends Comparable<S> {
     /**
      * The init score is the negative of the number of uninitialized genuine planning variables.
      * If it's 0 (which it usually is), the {@link PlanningSolution} is fully initialized
-     * and the score's {@link #toString()} does not mention it.
+     * and the score's {@link Object#toString()} does not mention it.
      * <p>
      * During {@link #compareTo(Object)}, it's even more important than the hard score:
      * if you don't want this behaviour, read about overconstrained planning in the reference manual.

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/Solver.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/Solver.java
@@ -30,11 +30,11 @@ import org.optaplanner.core.impl.solver.termination.Termination;
 
 /**
  * A Solver solves a planning problem.
- * Clients usually call {@link #solve(Solution_)} and then {@link #getBestSolution()}.
+ * Clients usually call {@link #solve} and then {@link #getBestSolution()}.
  * <p>
  * These methods are not thread-safe and should be called from the same thread,
  * except for the methods that are explicitly marked as thread-safe.
- * Note that despite that {@link #solve(Solution_)} is not thread-safe for clients of this class,
+ * Note that despite that {@link #solve} is not thread-safe for clients of this class,
  * that method is free to do multi-threading inside itself.
  * <p>
  * Build by a {@link SolverFactory}.
@@ -46,7 +46,7 @@ public interface Solver<Solution_> {
      * The best solution is the {@link PlanningSolution best solution} found during solving:
      * it might or might not be optimal, feasible or even initialized.
      * <p>
-     * The {@link #solve(Solution_)} method also returns the best solution,
+     * The {@link #solve} method also returns the best solution,
      * but this method is useful in rare asynchronous situations (although
      * {@link SolverEventListener#bestSolutionChanged(BestSolutionChangedEvent)} is often more appropriate).
      * <p>
@@ -84,14 +84,14 @@ public interface Solver<Solution_> {
 
     /**
      * This method is thread-safe.
-     * @return true if the {@link #solve(Solution_)} method is still running.
+     * @return true if the {@link #solve} method is still running.
      */
     boolean isSolving();
 
     /**
      * Notifies the solver that it should stop at its earliest convenience.
      * This method returns immediately, but it takes an undetermined time
-     * for the {@link #solve(Solution_)} to actually return.
+     * for the {@link #solve} to actually return.
      * <p>
      * This method is thread-safe.
      * @return true if successful

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/event/BestSolutionChangedEvent.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/event/BestSolutionChangedEvent.java
@@ -26,8 +26,8 @@ import org.optaplanner.core.impl.solver.DefaultSolver;
 import org.optaplanner.core.impl.solver.ProblemFactChange;
 
 /**
- * Delivered when the {@link PlanningSolution bets solution} changes during solving.
- * Delivered in the solver thread (which is the thread that calls {@link Solver#solve(Solution_)}).
+ * Delivered when the {@link PlanningSolution best solution} changes during solving.
+ * Delivered in the solver thread (which is the thread that calls {@link Solver#solve}).
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
 public class BestSolutionChangedEvent<Solution_> extends EventObject {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/partitionedsearch/PartitionedSearchPhaseConfig.java
@@ -84,12 +84,12 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
 
     /**
      * Similar to a thread pool size, but instead of limiting the number of {@link Thread}s,
-     * it limits the number of {@link Thread.State#RUNNABLE} {@link Thread}s to avoid consuming all CPU resources
-     * (which would starve UI, Servlets and REST threads).
+     * it limits the number of {@link java.lang.Thread.State#RUNNABLE runnable} {@link Thread}s to avoid consuming all
+     * CPU resources (which would starve UI, Servlets and REST threads).
      * <p/>
      * The number of {@link Thread}s is always equal to the number of partitions returned by {@link SolutionPartitioner#splitWorkingSolution(ScoreDirector)},
      * because otherwise some partitions would never run (especially with {@link Solver#terminateEarly() asynchronous termination}).
-     * If this limit (or {@link Runtime#availableProcessors()) is lower than the number of partitions,
+     * If this limit (or {@link Runtime#availableProcessors()}) is lower than the number of partitions,
      * this results in a slower score calculation speed per partition {@link Solver}.
      * <p/>
      * Defaults to {@value #ACTIVE_THREAD_COUNT_AUTO} which consumes the majority
@@ -97,9 +97,9 @@ public class PartitionedSearchPhaseConfig extends PhaseConfig<PartitionedSearchP
      * on the machine from hanging.
      * <p/>
      * Use {@value #ACTIVE_THREAD_COUNT_UNLIMITED} to give it all CPU cores.
-     * This is usefull if you're handling the CPU consumption on an OS level.
+     * This is useful if you're handling the CPU consumption on an OS level.
      * @return null, a number, {@value #ACTIVE_THREAD_COUNT_AUTO}, {@value #ACTIVE_THREAD_COUNT_UNLIMITED}
-     * or a JavaScript calculation using {@value ConfigUtils#AVAILABLE_PROCESSOR_COUNT}.
+     * or a JavaScript calculation using {@value org.optaplanner.core.config.util.ConfigUtils#AVAILABLE_PROCESSOR_COUNT}.
      */
     public String getRunnablePartThreadLimit() {
         return runnablePartThreadLimit;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/util/ConfigUtils.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/util/ConfigUtils.java
@@ -183,7 +183,7 @@ public class ConfigUtils {
     }
 
     /**
-     * Name of the variable that represents {@link Runtime#availableProcessors()).
+     * Name of the variable that represents {@link Runtime#availableProcessors()}.
      */
     public static final String AVAILABLE_PROCESSOR_COUNT = "availableProcessorCount";
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/descriptor/EntityIndependentValueRangeDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/descriptor/EntityIndependentValueRangeDescriptor.java
@@ -25,10 +25,10 @@ import org.optaplanner.core.api.domain.valuerange.ValueRange;
 public interface EntityIndependentValueRangeDescriptor<Solution_> extends ValueRangeDescriptor<Solution_> {
 
     /**
-     * As specified by {@link #extractValueRange(Solution_, Object)}.
+     * As specified by {@link ValueRangeDescriptor#extractValueRange}.
      * @param solution never null
      * @return never null
-     * @see #extractValueRange(Solution_, Object)
+     * @see ValueRangeDescriptor#extractValueRange
      */
     ValueRange<?> extractValueRange(Solution_ solution);
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/descriptor/ValueRangeDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/descriptor/ValueRangeDescriptor.java
@@ -52,7 +52,7 @@ public interface ValueRangeDescriptor<Solution_> {
     /**
      * @param solution never null
      * @param entity never null. To avoid this parameter,
-     * use {@link EntityIndependentValueRangeDescriptor#extractValueRange(Solution_)} instead.
+     * use {@link EntityIndependentValueRangeDescriptor#extractValueRange} instead.
      * @return never null
      */
     ValueRange<?> extractValueRange(Solution_ solution, Object entity);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/InnerScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/InnerScoreDirector.java
@@ -161,7 +161,7 @@ public interface InnerScoreDirector<Solution_> extends ScoreDirector<Solution_> 
      * @param workingScore never null
      * @param completedAction sometimes null, when assertion fails then the completedAction's {@link Object#toString()}
      * is included in the exception message
-     * @see InnerScoreDirectorFactory#assertScoreFromScratch(Solution_)
+     * @see InnerScoreDirectorFactory#assertScoreFromScratch
      */
     void assertWorkingScoreFromScratch(Score workingScore, Object completedAction);
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/InnerScoreDirectorFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/InnerScoreDirectorFactory.java
@@ -43,7 +43,7 @@ public interface InnerScoreDirectorFactory<Solution_> extends ScoreDirectorFacto
 
     /**
      * Like {@link #buildScoreDirector()}, but optionally disables {@link ConstraintMatch} tracking and location
-     * for more performance (presuming the {@link ScoreDirector} implementation actually supports it to begin with)
+     * for more performance (presuming the {@link ScoreDirector} implementation actually supports it to begin with).
      * @param locatorEnabled true if a {@link ScoreDirector} implementation should track all working objects
      * for {@link ScoreDirector#locateWorkingObject(Object)}
      * @param constraintMatchEnabledPreference false if a {@link ScoreDirector} implementation

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/easy/EasyScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/easy/EasyScoreDirector.java
@@ -67,7 +67,7 @@ public class EasyScoreDirector<Solution_>
     /**
      * {@link ConstraintMatchTotal}s are not supported by this {@link ScoreDirector} implementation.
      * @throws IllegalStateException always
-     * @return
+     * @return throws exception
      */
     @Override
     public Collection<ConstraintMatchTotal> getConstraintMatchTotals() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/incremental/ConstraintMatchAwareIncrementalScoreCalculator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/incremental/ConstraintMatchAwareIncrementalScoreCalculator.java
@@ -35,17 +35,16 @@ public interface ConstraintMatchAwareIncrementalScoreCalculator<Solution_>
     /**
      * Allows for increased performance by tracking only if constraintMatchEnabled is true.
      * <p>
-     * Every implementation should call {@link #resetWorkingSolution(Solution_)}
+     * Every implementation should call {@link #resetWorkingSolution}
      * and only handle the constraintMatchEnabled parameter specifically (or ignore it).
-     * @param workingSolution never null, to pass to {@link #resetWorkingSolution(Solution_)}.
+     * @param workingSolution never null, to pass to {@link #resetWorkingSolution}.
      * @param constraintMatchEnabled true if {@link #getConstraintMatchTotals()} might be called.
      */
     void resetWorkingSolution(Solution_ workingSolution, boolean constraintMatchEnabled);
 
     /**
      * @return never null
-     * @throws IllegalStateException if {@link #resetWorkingSolution(Solution_, boolean)}'s
-     * constraintMatchEnabled parameter was false
+     * @throws IllegalStateException if {@link #resetWorkingSolution}'s constraintMatchEnabled parameter was false
      * @see ScoreDirector#getConstraintMatchTotals()
      */
     Collection<ConstraintMatchTotal> getConstraintMatchTotals();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/DefaultSolverScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/scope/DefaultSolverScope.java
@@ -42,7 +42,9 @@ public class DefaultSolverScope<Solution_> {
     protected int startingSolverCount;
     protected Random workingRandom;
     protected InnerScoreDirector<Solution_> scoreDirector;
-    /** Used for capping CPU power usage in multi-threaded scenario's */
+    /**
+     * Used for capping CPU power usage in multi-threaded scenarios.
+     */
     protected Semaphore runnableThreadSemaphore = null;
 
     protected Long startingSystemTimeMillis;

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/Meeting.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/meetingscheduling/domain/Meeting.java
@@ -26,7 +26,7 @@ public class Meeting extends AbstractPersistable {
 
     private String topic;
     /**
-     * Multiply by {@link TimeGrain#GRAIN_LENGTH_IN_MINUTES} to get duration in minutes
+     * Multiply by {@link TimeGrain#GRAIN_LENGTH_IN_MINUTES} to get duration in minutes.
      */
     private int durationInGrains;
 

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/bendable/BendableScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/bendable/BendableScoreVerifier.java
@@ -41,7 +41,7 @@ public class BendableScoreVerifier<Solution_> extends AbstractScoreVerifier<Solu
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param hardLevel {@code 0 <= hardLevel <} {@code hardLevelSize}.
      * The {@code scoreLevel} is {@code hardLevel} for hard levels and {@code softLevel + hardLevelSize} for soft levels.

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/bendablebigdecimal/BendableBigDecimalScoreVerifier.java
@@ -43,7 +43,7 @@ public class BendableBigDecimalScoreVerifier<Solution_> extends AbstractScoreVer
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param hardLevel {@code 0 <= hardLevel <} {@code hardLevelSize}.
      * The {@code scoreLevel} is {@code hardLevel} for hard levels and {@code softLevel + hardLevelSize} for soft levels.

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/bendablelong/BendableLongScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/bendablelong/BendableLongScoreVerifier.java
@@ -41,7 +41,7 @@ public class BendableLongScoreVerifier<Solution_> extends AbstractScoreVerifier<
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param hardLevel {@code 0 <= hardLevel <} {@code hardLevelSize}.
      * The {@code scoreLevel} is {@code hardLevel} for hard levels and {@code softLevel + hardLevelSize} for soft levels.

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/hardmediumsoft/HardMediumSoftScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/hardmediumsoft/HardMediumSoftScoreVerifier.java
@@ -37,7 +37,7 @@ public class HardMediumSoftScoreVerifier<Solution_> extends AbstractScoreVerifie
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param expectedWeight the total weight for all matches of that 1 constraint
      * @param solution never null, the actual {@link PlanningSolution}
@@ -61,7 +61,7 @@ public class HardMediumSoftScoreVerifier<Solution_> extends AbstractScoreVerifie
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param expectedWeight the total weight for all matches of that 1 constraint
      * @param solution never null, the actual {@link PlanningSolution}

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/hardmediumsoftlong/HardMediumSoftLongScoreVerifier.java
@@ -37,7 +37,7 @@ public class HardMediumSoftLongScoreVerifier<Solution_> extends AbstractScoreVer
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param expectedWeight the total weight for all matches of that 1 constraint
      * @param solution never null, the actual {@link PlanningSolution}
@@ -61,7 +61,7 @@ public class HardMediumSoftLongScoreVerifier<Solution_> extends AbstractScoreVer
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param expectedWeight the total weight for all matches of that 1 constraint
      * @param solution never null, the actual {@link PlanningSolution}

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/hardsoft/HardSoftScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/hardsoft/HardSoftScoreVerifier.java
@@ -39,7 +39,7 @@ public class HardSoftScoreVerifier<Solution_> extends AbstractScoreVerifier<Solu
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param expectedWeight the total weight for all matches of that 1 constraint
      * @param solution never null, the actual {@link PlanningSolution}

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/hardsoftbigdecimal/HardSoftBigDecimalScoreVerifier.java
@@ -39,7 +39,7 @@ public class HardSoftBigDecimalScoreVerifier<Solution_> extends AbstractScoreVer
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param expectedWeight never null, the total weight for all matches of that 1 constraint
      * @param solution never null, the actual {@link PlanningSolution}

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/hardsoftlong/HardSoftLongScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/hardsoftlong/HardSoftLongScoreVerifier.java
@@ -37,7 +37,7 @@ public class HardSoftLongScoreVerifier<Solution_> extends AbstractScoreVerifier<
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param expectedWeight the total weight for all matches of that 1 constraint
      * @param solution never null, the actual {@link PlanningSolution}

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/simple/SimpleScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/simple/SimpleScoreVerifier.java
@@ -37,7 +37,7 @@ public class SimpleScoreVerifier<Solution_> extends AbstractScoreVerifier<Soluti
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param expectedWeight the total weight for all matches of that 1 constraint
      * @param solution never null, the actual {@link PlanningSolution}

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/simplebigdecimal/SimpleBigDecimalScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/simplebigdecimal/SimpleBigDecimalScoreVerifier.java
@@ -39,7 +39,7 @@ public class SimpleBigDecimalScoreVerifier<Solution_> extends AbstractScoreVerif
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param expectedWeight never null, the total weight for all matches of that 1 constraint
      * @param solution never null, the actual {@link PlanningSolution}

--- a/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/simplelong/SimpleLongScoreVerifier.java
+++ b/optaplanner-test/src/main/java/org/optaplanner/test/impl/score/buildin/simplelong/SimpleLongScoreVerifier.java
@@ -37,7 +37,7 @@ public class SimpleLongScoreVerifier<Solution_> extends AbstractScoreVerifier<So
 
     /**
      * Assert that the constraint (which is usually a score rule) of {@link PlanningSolution}
-     * has the expected weight for that score level
+     * has the expected weight for that score level.
      * @param constraintName never null, the name of the constraint, which is usually the name of the score rule
      * @param expectedWeight the total weight for all matches of that 1 constraint
      * @param solution never null, the actual {@link PlanningSolution}


### PR DESCRIPTION
Most frequent issue was broken links due to usage of `Solution_`
parameter in method references. Javadoc tool cannot handle that but when
the method reference is used without parameters, the link is generated
correctly.

Another issue was with `@value` tag. It appears to require FQCN when
referencing a different class.

Also fixes missing period at ends of first sentences and typos.