### PR TITLE
Compiler warnings elimination - low hanging fruit

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/score/holder/AbstractScoreHolder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/score/holder/AbstractScoreHolder.java
@@ -234,7 +234,7 @@ public abstract class AbstractScoreHolder implements ScoreHolder, Serializable {
     }
 
     private void putConstraintUndoListener(RuleContext kcontext, int scoreLevel, ConstraintUndoListener constraintUndoListener) {
-        AgendaItem agendaItem = (AgendaItem) kcontext.getMatch();
+        AgendaItem<?> agendaItem = (AgendaItem) kcontext.getMatch();
         ActivationUnMatchListener activationUnMatchListener = agendaItem.getActivationUnMatchListener();
         if (activationUnMatchListener != null) {
             MultiLevelActivationUnMatchListener multiLevelActivationUnMatchListener = (MultiLevelActivationUnMatchListener) activationUnMatchListener;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/ReflectionHelper.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/ReflectionHelper.java
@@ -98,7 +98,7 @@ public final class ReflectionHelper {
      * @param propertyName never null
      * @return true if that getter exists
      */
-    public static boolean hasGetterMethod(Class containingClass, String propertyName) {
+    public static boolean hasGetterMethod(Class<?> containingClass, String propertyName) {
         return getGetterMethod(containingClass, propertyName) != null;
     }
 
@@ -107,7 +107,7 @@ public final class ReflectionHelper {
      * @param propertyName never null
      * @return true if that getter exists
      */
-    public static Method getGetterMethod(Class containingClass, String propertyName) {
+    public static Method getGetterMethod(Class<?> containingClass, String propertyName) {
         String getterName = PROPERTY_ACCESSOR_PREFIX_GET
                 + (propertyName.isEmpty() ? "" : propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1));
         try {
@@ -134,7 +134,7 @@ public final class ReflectionHelper {
      * @param propertyName never null
      * @return null if it doesn't exist
      */
-    public static Method getSetterMethod(Class containingClass, Class propertyType, String propertyName) {
+    public static Method getSetterMethod(Class<?> containingClass, Class<?> propertyType, String propertyName) {
         String setterName = PROPERTY_MUTATOR_PREFIX
                 + (propertyName.isEmpty() ? "" : propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1));
         try {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/BeanPropertyMemberAccessor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/common/accessor/BeanPropertyMemberAccessor.java
@@ -36,7 +36,7 @@ public final class BeanPropertyMemberAccessor implements MemberAccessor {
     public BeanPropertyMemberAccessor(Method getterMethod) {
         this.getterMethod = getterMethod;
         getterMethod.setAccessible(true); // Performance hack by avoiding security checks
-        Class declaringClass = getterMethod.getDeclaringClass();
+        Class<?> declaringClass = getterMethod.getDeclaringClass();
         if (!ReflectionHelper.isGetterMethod(getterMethod)) {
             throw new IllegalArgumentException("The getterMethod (" + getterMethod + ") is not a valid getter.");
         }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/locator/LocationStrategyResolver.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/locator/LocationStrategyResolver.java
@@ -41,7 +41,7 @@ public class LocationStrategyResolver {
 
     private final LocationStrategyType locationStrategyType;
 
-    private final ConcurrentMap<Class, LocationStrategy> decisionCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Class<?>, LocationStrategy> decisionCache = new ConcurrentHashMap<>();
 
     public LocationStrategyResolver(LocationStrategyType locationStrategyType) {
         this.locationStrategyType = locationStrategyType;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/AbstractSolution.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/AbstractSolution.java
@@ -103,7 +103,7 @@ public abstract class AbstractSolution<S extends Score> implements Serializable 
     }
 
     private boolean isFieldAPlanningEntityPropertyOrPlanningEntityCollectionProperty(Field field,
-            Class fieldInstanceClass) {
+            Class<?> fieldInstanceClass) {
         if (field.isAnnotationPresent(PlanningEntityProperty.class)
                 || field.isAnnotationPresent(PlanningEntityCollectionProperty.class)) {
             return true;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -576,12 +576,13 @@ public class SolutionDescriptor<Solution_> {
 
     private void determineGlobalShadowOrder() {
         // Topological sorting with Kahn's algorithm
-        List<Pair<ShadowVariableDescriptor, Integer>> pairList = new ArrayList<>();
-        Map<ShadowVariableDescriptor, Pair<ShadowVariableDescriptor, Integer>> shadowToPairMap = new HashMap<>();
+        List<Pair<ShadowVariableDescriptor<Solution_>, Integer>> pairList = new ArrayList<>();
+        Map<ShadowVariableDescriptor<Solution_>, Pair<ShadowVariableDescriptor<Solution_>, Integer>> shadowToPairMap
+                = new HashMap<>();
         for (EntityDescriptor<Solution_> entityDescriptor : entityDescriptorMap.values()) {
             for (ShadowVariableDescriptor<Solution_> shadow : entityDescriptor.getDeclaredShadowVariableDescriptors()) {
                 int sourceSize = shadow.getSourceVariableDescriptorList().size();
-                Pair<ShadowVariableDescriptor, Integer> pair = MutablePair.of(shadow, sourceSize);
+                Pair<ShadowVariableDescriptor<Solution_>, Integer> pair = MutablePair.of(shadow, sourceSize);
                 pairList.add(pair);
                 shadowToPairMap.put(shadow, pair);
             }
@@ -589,7 +590,7 @@ public class SolutionDescriptor<Solution_> {
         for (EntityDescriptor<Solution_> entityDescriptor : entityDescriptorMap.values()) {
             for (GenuineVariableDescriptor<Solution_> genuine : entityDescriptor.getDeclaredGenuineVariableDescriptors()) {
                 for (ShadowVariableDescriptor<Solution_> sink : genuine.getSinkVariableDescriptorList()) {
-                    Pair<ShadowVariableDescriptor, Integer> sinkPair = shadowToPairMap.get(sink);
+                    Pair<ShadowVariableDescriptor<Solution_>, Integer> sinkPair = shadowToPairMap.get(sink);
                     sinkPair.setValue(sinkPair.getValue() - 1);
                 }
             }
@@ -597,7 +598,7 @@ public class SolutionDescriptor<Solution_> {
         int globalShadowOrder = 0;
         while (!pairList.isEmpty()) {
             Collections.sort(pairList, (a, b) -> Integer.compare(a.getValue(), b.getValue()));
-            Pair<ShadowVariableDescriptor, Integer> pair = pairList.remove(0);
+            Pair<ShadowVariableDescriptor<Solution_>, Integer> pair = pairList.remove(0);
             ShadowVariableDescriptor<Solution_> shadow = pair.getKey();
             if (pair.getValue() != 0) {
                 if (pair.getValue() < 0) {
@@ -611,7 +612,7 @@ public class SolutionDescriptor<Solution_> {
                         + ") and also earlier than its sinks (" + shadow.getSinkVariableDescriptorList() + ").");
             }
             for (ShadowVariableDescriptor<Solution_> sink : shadow.getSinkVariableDescriptorList()) {
-                Pair<ShadowVariableDescriptor, Integer> sinkPair = shadowToPairMap.get(sink);
+                Pair<ShadowVariableDescriptor<Solution_>, Integer> sinkPair = shadowToPairMap.get(sink);
                 sinkPair.setValue(sinkPair.getValue() - 1);
             }
             shadow.setGlobalShadowOrder(globalShadowOrder);
@@ -902,7 +903,7 @@ public class SolutionDescriptor<Solution_> {
         return count;
     }
 
-    public int countReinitializableVariables(ScoreDirector scoreDirector, Solution_ solution) {
+    public int countReinitializableVariables(ScoreDirector<Solution_> scoreDirector, Solution_ solution) {
         int count = 0;
         for (Iterator<Object> it = extractAllEntitiesIterator(solution); it.hasNext(); ) {
             Object entity = it.next();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -451,7 +451,7 @@ public class SolutionDescriptor<Solution_> {
                             "The solutionClass (" + solutionClass + ") cannot be directly a "
                             + AbstractSolution.class.getSimpleName() + ", but a subclass would be ok.");
                 }
-                Class baseClass = solutionClass;
+                Class<?> baseClass = solutionClass;
                 while (baseClass.getSuperclass() != AbstractSolution.class) {
                     baseClass = baseClass.getSuperclass();
                     if (baseClass == null) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/mutation/MutationCounter.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/solution/mutation/MutationCounter.java
@@ -46,7 +46,7 @@ public class MutationCounter<Solution_> {
         for (EntityDescriptor<Solution_> entityDescriptor : solutionDescriptor.getGenuineEntityDescriptors()) {
             List<Object> aEntities = entityDescriptor.extractEntities(a);
             List<Object> bEntities = entityDescriptor.extractEntities(b);
-            for (Iterator aIt = aEntities.iterator(), bIt = bEntities.iterator(); aIt.hasNext() && bIt.hasNext(); ) {
+            for (Iterator<Object> aIt = aEntities.iterator(), bIt = bEntities.iterator(); aIt.hasNext() && bIt.hasNext(); ) {
                 Object aEntity =  aIt.next();
                 Object bEntity =  bIt.next();
                 for (GenuineVariableDescriptor<Solution_> variableDescriptor : entityDescriptor.getGenuineVariableDescriptors()) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/descriptor/AbstractFromPropertyValueRangeDescriptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/domain/valuerange/descriptor/AbstractFromPropertyValueRangeDescriptor.java
@@ -107,7 +107,7 @@ public abstract class AbstractFromPropertyValueRangeDescriptor<Solution_>
                 // with the variableDescriptor's generic type's type arguments
                 typeArgument = ((ParameterizedType) typeArgument).getRawType();
             }
-            Class collectionElementClass;
+            Class<?> collectionElementClass;
             if (typeArgument instanceof Class) {
                 collectionElementClass = ((Class) typeArgument);
             } else {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/scope/LocalSearchStepScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/scope/LocalSearchStepScope.java
@@ -25,7 +25,7 @@ import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
  */
 public class LocalSearchStepScope<Solution_> extends AbstractStepScope<Solution_> {
 
-    private final LocalSearchPhaseScope phaseScope;
+    private final LocalSearchPhaseScope<Solution_> phaseScope;
 
     private double timeGradient = Double.NaN;
     private Move step = null;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
@@ -130,7 +130,7 @@ public class DefaultPartitionedSearchPhase<Solution_> extends AbstractPhase<Solu
                     }
                 });
             }
-            for (PartitionChangeMove step : partitionQueue) {
+            for (PartitionChangeMove<Solution_> step : partitionQueue) {
                 PartitionedSearchStepScope<Solution_> stepScope = new PartitionedSearchStepScope<>(phaseScope);
                 stepStarted(stepScope);
                 stepScope.setStep(step);
@@ -188,7 +188,7 @@ public class DefaultPartitionedSearchPhase<Solution_> extends AbstractPhase<Solu
     @Override
     public void stepEnded(PartitionedSearchStepScope<Solution_> stepScope) {
         super.stepEnded(stepScope);
-        PartitionedSearchPhaseScope phaseScope = stepScope.getPhaseScope();
+        PartitionedSearchPhaseScope<Solution_> phaseScope = stepScope.getPhaseScope();
         if (logger.isDebugEnabled()) {
             logger.debug("{}    PS step ({}), time spent ({}), score ({}), {} best score ({})," +
                     " picked move ({}).",

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueue.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueue.java
@@ -32,8 +32,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class is thread-safe.
+ * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
  */
-public class PartitionQueue<Solution_> implements Iterable<PartitionChangeMove> {
+public class PartitionQueue<Solution_> implements Iterable<PartitionChangeMove<Solution_>> {
 
     protected final transient Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -105,15 +106,15 @@ public class PartitionQueue<Solution_> implements Iterable<PartitionChangeMove> 
     }
 
     @Override
-    public Iterator<PartitionChangeMove> iterator() {
+    public Iterator<PartitionChangeMove<Solution_>> iterator() {
         // TODO Currently doesn't be support to be called twice on the same instance
         return new PartitionQueueIterator();
     }
 
-    private class PartitionQueueIterator extends UpcomingSelectionIterator<PartitionChangeMove> {
+    private class PartitionQueueIterator extends UpcomingSelectionIterator<PartitionChangeMove<Solution_>> {
 
         @Override
-        protected PartitionChangeMove createUpcomingSelection() {
+        protected PartitionChangeMove<Solution_> createUpcomingSelection() {
             while (true) {
                 PartitionChangedEvent<Solution_> triggerEvent;
                 try {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/event/PhaseLifecycleSupport.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/phase/event/PhaseLifecycleSupport.java
@@ -27,37 +27,37 @@ import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
 public class PhaseLifecycleSupport<Solution_> extends AbstractEventSupport<PhaseLifecycleListener<Solution_>> {
 
     public void fireSolvingStarted(DefaultSolverScope<Solution_> solverScope) {
-        for (PhaseLifecycleListener phaseLifecycleListener : eventListenerSet) {
+        for (PhaseLifecycleListener<Solution_> phaseLifecycleListener : eventListenerSet) {
             phaseLifecycleListener.solvingStarted(solverScope);
         }
     }
 
     public void firePhaseStarted(AbstractPhaseScope<Solution_> phaseScope) {
-        for (PhaseLifecycleListener phaseLifecycleListener : eventListenerSet) {
+        for (PhaseLifecycleListener<Solution_> phaseLifecycleListener : eventListenerSet) {
             phaseLifecycleListener.phaseStarted(phaseScope);
         }
     }
 
     public void fireStepStarted(AbstractStepScope<Solution_> stepScope) {
-        for (PhaseLifecycleListener phaseLifecycleListener : eventListenerSet) {
+        for (PhaseLifecycleListener<Solution_> phaseLifecycleListener : eventListenerSet) {
             phaseLifecycleListener.stepStarted(stepScope);
         }
     }
 
     public void fireStepEnded(AbstractStepScope<Solution_> stepScope) {
-        for (PhaseLifecycleListener phaseLifecycleListener : eventListenerSet) {
+        for (PhaseLifecycleListener<Solution_> phaseLifecycleListener : eventListenerSet) {
             phaseLifecycleListener.stepEnded(stepScope);
         }
     }
 
     public void firePhaseEnded(AbstractPhaseScope<Solution_> phaseScope) {
-        for (PhaseLifecycleListener phaseLifecycleListener : eventListenerSet) {
+        for (PhaseLifecycleListener<Solution_> phaseLifecycleListener : eventListenerSet) {
             phaseLifecycleListener.phaseEnded(phaseScope);
         }
     }
 
     public void fireSolvingEnded(DefaultSolverScope<Solution_> solverScope) {
-        for (PhaseLifecycleListener phaseLifecycleListener : eventListenerSet) {
+        for (PhaseLifecycleListener<Solution_> phaseLifecycleListener : eventListenerSet) {
             phaseLifecycleListener.solvingEnded(solverScope);
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/XStreamXmlSolverFactory.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/XStreamXmlSolverFactory.java
@@ -79,7 +79,7 @@ public class XStreamXmlSolverFactory<Solution_> extends AbstractSolverFactory<So
      * @param xStreamAnnotations never null
      * @see XStream#processAnnotations(Class[])
      */
-    public void addXStreamAnnotations(Class... xStreamAnnotations) {
+    public void addXStreamAnnotations(Class<?>... xStreamAnnotations) {
         xStream.processAnnotations(xStreamAnnotations);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/recaller/BestSolutionRecaller.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/recaller/BestSolutionRecaller.java
@@ -42,7 +42,7 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
     protected boolean assertShadowVariablesAreNotStale = false;
     protected boolean assertBestScoreIsUnmodified = false;
 
-    protected SolverEventSupport solverEventSupport;
+    protected SolverEventSupport<Solution_> solverEventSupport;
 
     public void setAssertInitialScoreFromScratch(boolean assertInitialScoreFromScratch) {
         this.assertInitialScoreFromScratch = assertInitialScoreFromScratch;
@@ -56,7 +56,7 @@ public class BestSolutionRecaller<Solution_> extends PhaseLifecycleListenerAdapt
         this.assertBestScoreIsUnmodified = assertBestScoreIsUnmodified;
     }
 
-    public void setSolverEventSupport(SolverEventSupport solverEventSupport) {
+    public void setSolverEventSupport(SolverEventSupport<Solution_> solverEventSupport) {
         this.solverEventSupport = solverEventSupport;
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/score/holder/AbstractScoreHolderTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/score/holder/AbstractScoreHolderTest.java
@@ -19,6 +19,7 @@ package org.optaplanner.core.api.score.holder;
 import java.util.Collections;
 import java.util.List;
 
+import org.drools.core.beliefsystem.ModedAssertion;
 import org.drools.core.common.AgendaItem;
 import org.drools.core.common.AgendaItemImpl;
 import org.kie.api.definition.rule.Rule;
@@ -29,9 +30,14 @@ import static org.mockito.Mockito.*;
 
 public abstract class AbstractScoreHolderTest {
 
+    private static interface TestModedAssertion extends ModedAssertion<TestModedAssertion> {
+    }
+
     protected RuleContext mockRuleContext(String ruleName) {
         RuleContext kcontext = mock(RuleContext.class);
-        AgendaItem agendaItem = new AgendaItemImpl() {
+        AgendaItemImpl<TestModedAssertion> agendaItem = new AgendaItemImpl<TestModedAssertion>() {
+            private static final long serialVersionUID = 1L;
+
             @Override
             public List<Object> getObjects() {
                 return Collections.emptyList();
@@ -46,7 +52,7 @@ public abstract class AbstractScoreHolderTest {
     }
 
     protected void callUnMatch(RuleContext ruleContext) {
-        AgendaItem agendaItem = (AgendaItem) ruleContext.getMatch();
+        AgendaItem<?> agendaItem = (AgendaItem) ruleContext.getMatch();
         agendaItem.getActivationUnMatchListener().unMatch(mock(RuleRuntime.class), agendaItem);
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverFactoryTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/api/solver/SolverFactoryTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.*;
 public class SolverFactoryTest {
 
     @Test
+    @SuppressWarnings("rawtypes")
     public void testdataSolverConfigWithoutGenericsForBackwardsCompatibility() {
         SolverFactory solverFactory = SolverFactory.createFromXmlResource(
                 "org/optaplanner/core/api/solver/testdataSolverConfig.xml");

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/SelectorTestUtils.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/selector/SelectorTestUtils.java
@@ -52,13 +52,13 @@ public class SelectorTestUtils {
         return solutionDescriptor;
     }
 
-    public static EntityDescriptor mockEntityDescriptor(Class entityClass) {
+    public static EntityDescriptor mockEntityDescriptor(Class<?> entityClass) {
         EntityDescriptor entityDescriptor = mock(EntityDescriptor.class);
         when(entityDescriptor.getEntityClass()).thenReturn(entityClass);
         return entityDescriptor;
     }
 
-    public static GenuineVariableDescriptor mockVariableDescriptor(Class entityClass, String variableName) {
+    public static GenuineVariableDescriptor mockVariableDescriptor(Class<?> entityClass, String variableName) {
         EntityDescriptor entityDescriptor = mockEntityDescriptor(entityClass);
         return mockVariableDescriptor(entityDescriptor, variableName);
     }
@@ -71,7 +71,7 @@ public class SelectorTestUtils {
         return variableDescriptor;
     }
 
-    public static EntitySelector mockEntitySelector(Class entityClass, Object... entities) {
+    public static EntitySelector mockEntitySelector(Class<?> entityClass, Object... entities) {
         EntityDescriptor entityDescriptor = mockEntityDescriptor(entityClass);
         return mockEntitySelector(entityDescriptor, entities);
     }
@@ -94,7 +94,7 @@ public class SelectorTestUtils {
         return entitySelector;
     }
 
-    public static ValueSelector mockValueSelector(Class entityClass, String variableName, Object... values) {
+    public static ValueSelector mockValueSelector(Class<?> entityClass, String variableName, Object... values) {
         GenuineVariableDescriptor variableDescriptor = mockVariableDescriptor(entityClass, variableName);
         return mockValueSelector(variableDescriptor, values);
     }
@@ -116,13 +116,13 @@ public class SelectorTestUtils {
         return valueSelector;
     }
 
-    public static ValueSelector mockValueSelectorForEntity(Class entityClass, Object entity, String variableName,
+    public static ValueSelector mockValueSelectorForEntity(Class<?> entityClass, Object entity, String variableName,
             Object... values) {
         return mockValueSelectorForEntity(entityClass, variableName,
                 ImmutableListMultimap.builder().putAll(entity, values).build());
     }
 
-    public static ValueSelector mockValueSelectorForEntity(Class entityClass, String variableName,
+    public static ValueSelector mockValueSelectorForEntity(Class<?> entityClass, String variableName,
             ListMultimap<Object, Object> entityToValues) {
         GenuineVariableDescriptor variableDescriptor = mockVariableDescriptor(entityClass, variableName);
         return mockValueSelectorForEntity(variableDescriptor, entityToValues);
@@ -144,7 +144,7 @@ public class SelectorTestUtils {
         return valueSelector;
     }
 
-    public static EntityIndependentValueSelector mockEntityIndependentValueSelector(Class entityClass, String variableName,
+    public static EntityIndependentValueSelector mockEntityIndependentValueSelector(Class<?> entityClass, String variableName,
             Object... values) {
         GenuineVariableDescriptor variableDescriptor = mockVariableDescriptor(entityClass, variableName);
         when(variableDescriptor.isValueRangeEntityIndependent()).thenReturn(true);
@@ -166,7 +166,7 @@ public class SelectorTestUtils {
         return valueSelector;
     }
 
-    public static MoveSelector mockMoveSelector(Class moveClass,
+    public static MoveSelector mockMoveSelector(Class<?> moveClass,
             Move... moves) {
         MoveSelector moveSelector = mock(MoveSelector.class);
         final List<Move> moveList = Arrays.<Move>asList(moves);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/partitionedsearch/queue/PartitionQueueTest.java
@@ -33,8 +33,8 @@ public class PartitionQueueTest {
 
     @Test
     public void addMove() throws ExecutionException, InterruptedException {
-        PartitionQueue partitionQueue = new PartitionQueue(3);
-        Iterator it = partitionQueue.iterator();
+        PartitionQueue<TestdataSolution> partitionQueue = new PartitionQueue<>(3);
+        Iterator<PartitionChangeMove<TestdataSolution>> it = partitionQueue.iterator();
 
         PartitionChangeMove<TestdataSolution> moveA1 = buildMove();
         executorService.submit(() -> partitionQueue.addMove(0, moveA1)).get();
@@ -86,8 +86,8 @@ public class PartitionQueueTest {
 
     @Test
     public void addFinishWithNonEmptyQueue() throws ExecutionException, InterruptedException {
-        PartitionQueue partitionQueue = new PartitionQueue(3);
-        Iterator it = partitionQueue.iterator();
+        PartitionQueue<TestdataSolution> partitionQueue = new PartitionQueue<>(3);
+        Iterator<PartitionChangeMove<TestdataSolution>> it = partitionQueue.iterator();
 
         PartitionChangeMove<TestdataSolution> moveA1 = buildMove();
         executorService.submit(() -> partitionQueue.addMove(0, moveA1)).get();
@@ -107,8 +107,8 @@ public class PartitionQueueTest {
 
     @Test()
     public void addExceptionWithNonEmptyQueue() throws ExecutionException, InterruptedException {
-        PartitionQueue partitionQueue = new PartitionQueue(3);
-        Iterator it = partitionQueue.iterator();
+        PartitionQueue<TestdataSolution> partitionQueue = new PartitionQueue<>(3);
+        Iterator<PartitionChangeMove<TestdataSolution>> it = partitionQueue.iterator();
 
         PartitionChangeMove<TestdataSolution> moveA1 = buildMove();
         executorService.submit(() -> partitionQueue.addMove(0, moveA1)).get();

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -213,7 +213,7 @@ public class PlannerAssert extends Assert {
                     + "->" + convertToCodeAssertable(changeMove.getToPlanningValue()).getCode();
             return () -> code;
         } else if (o instanceof SwapMove) {
-            SwapMove swapMove = (SwapMove) o;
+            SwapMove<?> swapMove = (SwapMove) o;
             final String code = convertToCodeAssertable(swapMove.getLeftEntity()).getCode()
                     + "<->" + convertToCodeAssertable(swapMove.getRightEntity()).getCode();
             return () -> code;
@@ -226,7 +226,7 @@ public class PlannerAssert extends Assert {
             final String code = codeBuilder.substring(1);
             return () -> code;
         } else if (o instanceof List) {
-            List list = (List) o;
+            List<?> list = (List) o;
             StringBuilder codeBuilder = new StringBuilder("[");
             boolean firstElement = true;
             for (Object element : list) {

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -63,11 +63,11 @@ public class PlannerAssert extends Assert {
     // Missing JUnit methods
     // ************************************************************************
 
-    public static void assertInstanceOf(Class expectedClass, Object actualInstance) {
+    public static void assertInstanceOf(Class<?> expectedClass, Object actualInstance) {
         assertInstanceOf(null, expectedClass, actualInstance);
     }
 
-    public static void assertInstanceOf(String message, Class expectedClass, Object actualInstance) {
+    public static void assertInstanceOf(String message, Class<?> expectedClass, Object actualInstance) {
         if (!expectedClass.isInstance(actualInstance)) {
             String cleanMessage = message == null ? "" : message;
             throw new ComparisonFailure(cleanMessage, expectedClass.getName(),
@@ -75,11 +75,11 @@ public class PlannerAssert extends Assert {
         }
     }
 
-    public static void assertNotInstanceOf(Class expectedClass, Object actualInstance) {
+    public static void assertNotInstanceOf(Class<?> expectedClass, Object actualInstance) {
         assertNotInstanceOf(null, expectedClass, actualInstance);
     }
 
-    public static void assertNotInstanceOf(String message, Class expectedClass, Object actualInstance) {
+    public static void assertNotInstanceOf(String message, Class<?> expectedClass, Object actualInstance) {
         if (expectedClass.isInstance(actualInstance)) {
             String cleanMessage = message == null ? "" : message;
             throw new ComparisonFailure(cleanMessage, "not " + expectedClass.getName(),


### PR DESCRIPTION
Each change eliminates one "rawtypes" warning and some of them also eliminate "unchecked conversion" warnings resulting from usage of the raw type.

These are easy and safe fixes because they mostly change local variables and fields.

86 warnings eliminated in optaplanner-core (3966→3880).