### PR TITLE
Compiler warnings - safe varargs

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/util/ConfigUtils.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/util/ConfigUtils.java
@@ -261,6 +261,7 @@ public class ConfigUtils {
         return memberStream.collect(Collectors.toList());
     }
 
+    @SafeVarargs
     public static Class<? extends Annotation> extractAnnotationClass(Member member,
             Class<? extends Annotation>... annotations) {
         Class<? extends Annotation> annotationClass = null;

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/composite/CompositeCountableValueRangeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/domain/valuerange/buildin/composite/CompositeCountableValueRangeTest.java
@@ -32,7 +32,8 @@ import static org.optaplanner.core.impl.testdata.util.PlannerAssert.*;
 
 public class CompositeCountableValueRangeTest {
 
-    private <T> CompositeCountableValueRange<T> createValueRange(List<T>... lists) {
+    @SafeVarargs
+    private static <T> CompositeCountableValueRange<T> createValueRange(List<T>... lists) {
         List<ListValueRange<T>> childValueRangeList = new ArrayList<>(lists.length);
         for (List<T> list : lists) {
             childValueRangeList.add(new ListValueRange<>(list));

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -87,10 +87,12 @@ public class PlannerAssert extends Assert {
         }
     }
 
+    @SafeVarargs
     public static <C extends Comparable<C>> void assertCompareToOrder(C... comparables) {
         assertCompareToOrder(Comparator.naturalOrder(), comparables);
     }
 
+    @SafeVarargs
     public static <T> void assertCompareToOrder(Comparator<T> comperator, T... objects) {
         for (int i = 0; i < objects.length; i++) {
             for (int j = i + 1; j < objects.length; j++) {
@@ -102,10 +104,12 @@ public class PlannerAssert extends Assert {
         }
     }
 
+    @SafeVarargs
     public static <C extends Comparable<C>> void assertCompareToEquals(C... comparables) {
         assertCompareToEquals(Comparator.naturalOrder(), comparables);
     }
 
+    @SafeVarargs
     public static <T> void assertCompareToEquals(Comparator<T> comperator, T... objects) {
         for (int i = 0; i < objects.length; i++) {
             for (int j = i + 1; j < objects.length; j++) {
@@ -117,11 +121,13 @@ public class PlannerAssert extends Assert {
         }
     }
 
+    @SafeVarargs
     public static <E> void assertCollectionContainsExactly(Collection<E> collection, E... elements) {
         assertCollectionContains(collection, elements);
         assertEquals(elements.length, collection.size());
     }
 
+    @SafeVarargs
     public static <E> void assertCollectionContains(Collection<E> collection, E... elements) {
         for (int i = 0; i < elements.length; i++) {
             if (!collection.contains(elements[i])) {
@@ -131,11 +137,13 @@ public class PlannerAssert extends Assert {
         }
     }
 
+    @SafeVarargs
     public static <K, V> void assertMapContainsKeysExactly(Map<K, V> map, K... keys) {
         assertMapContainsKeys(map, keys);
         assertEquals(keys.length, map.size());
     }
 
+    @SafeVarargs
     public static <K, V> void assertMapContainsKeys(Map<K, V> map, K... keys) {
         for (int i = 0; i < keys.length; i++) {
             if (!map.containsKey(keys[i])) {
@@ -179,6 +187,7 @@ public class PlannerAssert extends Assert {
         verify(phaseLifecycleListener, times(solvingCount)).solvingEnded(Matchers.<DefaultSolverScope>any());
     }
 
+    @SafeVarargs
     public static <O> void assertElementsOfIterator(Iterator<O> iterator, O... elements) {
         assertNotNull(iterator);
         for (O element : elements) {
@@ -187,6 +196,7 @@ public class PlannerAssert extends Assert {
         }
     }
 
+    @SafeVarargs
     public static <O> void assertAllElementsOfIterator(Iterator<O> iterator, O... elements) {
         assertElementsOfIterator(iterator, elements);
         assertFalse(iterator.hasNext());

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -93,13 +93,13 @@ public class PlannerAssert extends Assert {
     }
 
     @SafeVarargs
-    public static <T> void assertCompareToOrder(Comparator<T> comperator, T... objects) {
+    public static <T> void assertCompareToOrder(Comparator<T> comparator, T... objects) {
         for (int i = 0; i < objects.length; i++) {
             for (int j = i + 1; j < objects.length; j++) {
                 T a = objects[i];
                 T b = objects[j];
-                assertTrue("Object (" + a + ") must be lesser than object (" + b + ").", comperator.compare(a, b) < 0);
-                assertTrue("Object (" + b + ") must be greater than object (" + a + ").", comperator.compare(b, a) > 0);
+                assertTrue("Object (" + a + ") must be lesser than object (" + b + ").", comparator.compare(a, b) < 0);
+                assertTrue("Object (" + b + ") must be greater than object (" + a + ").", comparator.compare(b, a) > 0);
             }
         }
     }
@@ -110,13 +110,13 @@ public class PlannerAssert extends Assert {
     }
 
     @SafeVarargs
-    public static <T> void assertCompareToEquals(Comparator<T> comperator, T... objects) {
+    public static <T> void assertCompareToEquals(Comparator<T> comparator, T... objects) {
         for (int i = 0; i < objects.length; i++) {
             for (int j = i + 1; j < objects.length; j++) {
                 T a = objects[i];
                 T b = objects[j];
-                assertTrue("Object (" + a + ") must compare equal to object (" + b + ").", comperator.compare(a, b) == 0);
-                assertTrue("Object (" + b + ") must compare equal to object (" + a + ").", comperator.compare(b, a) == 0);
+                assertTrue("Object (" + a + ") must compare equal to object (" + b + ").", comparator.compare(a, b) == 0);
+                assertTrue("Object (" + b + ") must compare equal to object (" + a + ").", comparator.compare(b, a) == 0);
             }
         }
     }


### PR DESCRIPTION
Annotated methods have been checked for improper handling of the varargs
array and they appear to be safe. The varargs are always read-only and
no upcasting (e.g. to `Object[]`) takes place.

For explanation of heap pollution and when `@SafeVarargs` can be used see:
https://docs.oracle.com/javase/tutorial/java/generics/nonReifiableVarargsType.html
http://docs.oracle.com/javase/specs/jls/se7/html/jls-9.html#jls-9.6.3.7

33 warnings eliminated in optaplanner-core (3889→3856).