### PR TITLE
Compiler warnings - introduce Score_ parameter to exhaustive search

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/config/exhaustivesearch/NodeExplorationType.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/config/exhaustivesearch/NodeExplorationType.java
@@ -18,6 +18,7 @@ package org.optaplanner.core.config.exhaustivesearch;
 
 import java.util.Comparator;
 
+import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.exhaustivesearch.node.ExhaustiveSearchNode;
 import org.optaplanner.core.impl.exhaustivesearch.node.comparator.BreadthFirstNodeComparator;
 import org.optaplanner.core.impl.exhaustivesearch.node.comparator.DepthFirstNodeComparator;
@@ -32,18 +33,18 @@ public enum NodeExplorationType {
     SCORE_FIRST,
     OPTIMISTIC_BOUND_FIRST;
 
-    public Comparator<ExhaustiveSearchNode> buildNodeComparator(boolean scoreBounderEnabled) {
+    public <S extends Score<S>> Comparator<ExhaustiveSearchNode<S>> buildNodeComparator(boolean scoreBounderEnabled) {
         switch (this) {
             case ORIGINAL_ORDER:
-                return new OriginalOrderNodeComparator();
+                return new OriginalOrderNodeComparator<>();
             case DEPTH_FIRST:
-                return new DepthFirstNodeComparator(scoreBounderEnabled);
+                return new DepthFirstNodeComparator<>(scoreBounderEnabled);
             case BREADTH_FIRST:
-                return new BreadthFirstNodeComparator(scoreBounderEnabled);
+                return new BreadthFirstNodeComparator<>(scoreBounderEnabled);
             case SCORE_FIRST:
-                return new ScoreFirstNodeComparator(scoreBounderEnabled);
+                return new ScoreFirstNodeComparator<>(scoreBounderEnabled);
             case OPTIMISTIC_BOUND_FIRST:
-                return new OptimisticBoundFirstNodeComparator(scoreBounderEnabled);
+                return new OptimisticBoundFirstNodeComparator<>(scoreBounderEnabled);
             default:
                 throw new IllegalStateException("The nodeExplorationType ("
                         + this + ") is not implemented.");

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/event/ExhaustiveSearchPhaseLifecycleListener.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/event/ExhaustiveSearchPhaseLifecycleListener.java
@@ -17,21 +17,24 @@
 package org.optaplanner.core.impl.exhaustivesearch.event;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.exhaustivesearch.scope.ExhaustiveSearchPhaseScope;
 import org.optaplanner.core.impl.exhaustivesearch.scope.ExhaustiveSearchStepScope;
 import org.optaplanner.core.impl.solver.event.SolverLifecycleListener;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
+ * @param <Score_> the score type
  */
-public interface ExhaustiveSearchPhaseLifecycleListener<Solution_> extends SolverLifecycleListener<Solution_> {
+public interface ExhaustiveSearchPhaseLifecycleListener<Solution_, Score_ extends Score<Score_>>
+        extends SolverLifecycleListener<Solution_> {
 
-    void phaseStarted(ExhaustiveSearchPhaseScope<Solution_> phaseScope);
+    void phaseStarted(ExhaustiveSearchPhaseScope<Solution_, Score_> phaseScope);
 
-    void stepStarted(ExhaustiveSearchStepScope<Solution_> stepScope);
+    void stepStarted(ExhaustiveSearchStepScope<Solution_, Score_> stepScope);
 
-    void stepEnded(ExhaustiveSearchStepScope<Solution_> stepScope);
+    void stepEnded(ExhaustiveSearchStepScope<Solution_, Score_> stepScope);
 
-    void phaseEnded(ExhaustiveSearchPhaseScope<Solution_> phaseScope);
+    void phaseEnded(ExhaustiveSearchPhaseScope<Solution_, Score_> phaseScope);
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/ExhaustiveSearchNode.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/ExhaustiveSearchNode.java
@@ -21,24 +21,24 @@ import org.optaplanner.core.impl.exhaustivesearch.node.bounder.ScoreBounder;
 import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 
-public class ExhaustiveSearchNode {
+public class ExhaustiveSearchNode<S extends Score<S>> {
 
     private final ExhaustiveSearchLayer layer;
-    private final ExhaustiveSearchNode parent;
+    private final ExhaustiveSearchNode<S> parent;
     private final long breadth;
 
     // The move to get from the parent to this node
     private Move move;
     private Move undoMove;
-    private Score score;
+    private S score;
     /**
      * Never worse than the best possible score a leaf node below this node might lead to.
      * @see ScoreBounder#calculateOptimisticBound(ScoreDirector, Score)
      */
-    private Score optimisticBound;
+    private S optimisticBound;
     private boolean expandable = false;
 
-    public ExhaustiveSearchNode(ExhaustiveSearchLayer layer, ExhaustiveSearchNode parent) {
+    public ExhaustiveSearchNode(ExhaustiveSearchLayer layer, ExhaustiveSearchNode<S> parent) {
         this.layer = layer;
         this.parent = parent;
         this.breadth = layer.assignBreadth();
@@ -48,7 +48,7 @@ public class ExhaustiveSearchNode {
         return layer;
     }
 
-    public ExhaustiveSearchNode getParent() {
+    public ExhaustiveSearchNode<S> getParent() {
         return parent;
     }
 
@@ -72,19 +72,19 @@ public class ExhaustiveSearchNode {
         this.undoMove = undoMove;
     }
 
-    public Score getScore() {
+    public S getScore() {
         return score;
     }
 
-    public void setScore(Score score) {
+    public void setScore(S score) {
         this.score = score;
     }
 
-    public Score getOptimisticBound() {
+    public S getOptimisticBound() {
         return optimisticBound;
     }
 
-    public void setOptimisticBound(Score optimisticBound) {
+    public void setOptimisticBound(S optimisticBound) {
         this.optimisticBound = optimisticBound;
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/bounder/ScoreBounder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/bounder/ScoreBounder.java
@@ -22,7 +22,7 @@ import org.optaplanner.core.impl.score.definition.ScoreDefinition;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 import org.optaplanner.core.impl.score.trend.InitializingScoreTrend;
 
-public interface ScoreBounder {
+public interface ScoreBounder<S extends Score<S>> {
 
     /**
      * In OR terms, this is called the lower bound if they minimize, and upper bound if they maximize.
@@ -33,7 +33,7 @@ public interface ScoreBounder {
      * by initializing the uninitialized variables of the working {@link PlanningSolution}.
      * @see ScoreDefinition#buildOptimisticBound(InitializingScoreTrend, Score)
      */
-    Score calculateOptimisticBound(ScoreDirector scoreDirector, Score score);
+    S calculateOptimisticBound(ScoreDirector scoreDirector, S score);
 
     /**
      * In OR terms, this is called the upper bound if they minimize, and lower bound if they maximize.
@@ -44,6 +44,6 @@ public interface ScoreBounder {
      * by initializing the uninitialized variables of the working {@link PlanningSolution}.
      * @see ScoreDefinition#buildPessimisticBound(InitializingScoreTrend, Score)
      */
-    Score calculatePessimisticBound(ScoreDirector scoreDirector, Score score);
+    S calculatePessimisticBound(ScoreDirector scoreDirector, S score);
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/bounder/TrendBasedScoreBounder.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/bounder/TrendBasedScoreBounder.java
@@ -22,23 +22,23 @@ import org.optaplanner.core.impl.score.director.InnerScoreDirectorFactory;
 import org.optaplanner.core.impl.score.director.ScoreDirector;
 import org.optaplanner.core.impl.score.trend.InitializingScoreTrend;
 
-public class TrendBasedScoreBounder implements ScoreBounder {
+public class TrendBasedScoreBounder<S extends Score<S>> implements ScoreBounder<S> {
 
-    protected final ScoreDefinition scoreDefinition;
+    protected final ScoreDefinition<S> scoreDefinition;
     protected final InitializingScoreTrend initializingScoreTrend;
 
-    public TrendBasedScoreBounder(InnerScoreDirectorFactory scoreDirectorFactory) {
+    public TrendBasedScoreBounder(InnerScoreDirectorFactory<S> scoreDirectorFactory) {
         scoreDefinition = scoreDirectorFactory.getScoreDefinition();
         initializingScoreTrend = scoreDirectorFactory.getInitializingScoreTrend();
     }
 
     @Override
-    public Score calculateOptimisticBound(ScoreDirector scoreDirector, Score score) {
+    public S calculateOptimisticBound(ScoreDirector scoreDirector, S score) {
         return scoreDefinition.buildOptimisticBound(initializingScoreTrend, score);
     }
 
     @Override
-    public Score calculatePessimisticBound(ScoreDirector scoreDirector, Score score) {
+    public S calculatePessimisticBound(ScoreDirector scoreDirector, S score) {
         return scoreDefinition.buildPessimisticBound(initializingScoreTrend, score);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/BreadthFirstNodeComparator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/BreadthFirstNodeComparator.java
@@ -30,8 +30,10 @@ import org.optaplanner.core.impl.score.director.ScoreDirector;
  * <p>
  * A typical {@link ScoreBounder}'s {@link ScoreBounder#calculateOptimisticBound(ScoreDirector, Score)}
  * will be weak, which results in horrible performance scalability too.
+ * @param <S> the score type
  */
-public class BreadthFirstNodeComparator implements Comparator<ExhaustiveSearchNode>, Serializable {
+public class BreadthFirstNodeComparator<S extends Score<S>>
+        implements Comparator<ExhaustiveSearchNode<S>>, Serializable {
 
     private final boolean scoreBounderEnabled;
 
@@ -40,7 +42,7 @@ public class BreadthFirstNodeComparator implements Comparator<ExhaustiveSearchNo
     }
 
     @Override
-    public int compare(ExhaustiveSearchNode a, ExhaustiveSearchNode b) {
+    public int compare(ExhaustiveSearchNode<S> a, ExhaustiveSearchNode<S> b) {
         // Investigate shallower nodes first
         int aDepth = a.getDepth();
         int bDepth = b.getDepth();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/DepthFirstNodeComparator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/DepthFirstNodeComparator.java
@@ -19,12 +19,14 @@ package org.optaplanner.core.impl.exhaustivesearch.node.comparator;
 import java.io.Serializable;
 import java.util.Comparator;
 
+import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.exhaustivesearch.node.ExhaustiveSearchNode;
 
 /**
  * Investigate deeper nodes first.
+ * @param <S> the score type
  */
-public class DepthFirstNodeComparator implements Comparator<ExhaustiveSearchNode>, Serializable {
+public class DepthFirstNodeComparator<S extends Score<S>> implements Comparator<ExhaustiveSearchNode<S>>, Serializable {
 
     private final boolean scoreBounderEnabled;
 
@@ -33,7 +35,7 @@ public class DepthFirstNodeComparator implements Comparator<ExhaustiveSearchNode
     }
 
     @Override
-    public int compare(ExhaustiveSearchNode a, ExhaustiveSearchNode b) {
+    public int compare(ExhaustiveSearchNode<S> a, ExhaustiveSearchNode<S> b) {
         // Investigate deeper first
         int aDepth = a.getDepth();
         int bDepth = b.getDepth();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/OptimisticBoundFirstNodeComparator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/OptimisticBoundFirstNodeComparator.java
@@ -19,12 +19,15 @@ package org.optaplanner.core.impl.exhaustivesearch.node.comparator;
 import java.io.Serializable;
 import java.util.Comparator;
 
+import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.exhaustivesearch.node.ExhaustiveSearchNode;
 
 /**
  * Investigate the nodes with a better optimistic bound first, then deeper nodes.
+ * @param <S> the score type
  */
-public class OptimisticBoundFirstNodeComparator implements Comparator<ExhaustiveSearchNode>, Serializable {
+public class OptimisticBoundFirstNodeComparator<S extends Score<S>>
+        implements Comparator<ExhaustiveSearchNode<S>>, Serializable {
 
     public OptimisticBoundFirstNodeComparator(boolean scoreBounderEnabled) {
         if (!scoreBounderEnabled) {
@@ -34,7 +37,7 @@ public class OptimisticBoundFirstNodeComparator implements Comparator<Exhaustive
     }
 
     @Override
-    public int compare(ExhaustiveSearchNode a, ExhaustiveSearchNode b) {
+    public int compare(ExhaustiveSearchNode<S> a, ExhaustiveSearchNode<S> b) {
         // Investigate better optimistic bound first (ignore initScore to avoid depth first ordering)
         int optimisticBoundComparison = a.getOptimisticBound().compareTo(b.getOptimisticBound());
         if (optimisticBoundComparison < 0) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/OriginalOrderNodeComparator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/OriginalOrderNodeComparator.java
@@ -19,15 +19,18 @@ package org.optaplanner.core.impl.exhaustivesearch.node.comparator;
 import java.io.Serializable;
 import java.util.Comparator;
 
+import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.exhaustivesearch.node.ExhaustiveSearchNode;
 
 /**
  * Investigate deeper nodes first, in order.
+ * @param <S> score type
  */
-public class OriginalOrderNodeComparator implements Comparator<ExhaustiveSearchNode>, Serializable {
+public class OriginalOrderNodeComparator<S extends Score<S>>
+        implements Comparator<ExhaustiveSearchNode<S>>, Serializable {
 
     @Override
-    public int compare(ExhaustiveSearchNode a, ExhaustiveSearchNode b) {
+    public int compare(ExhaustiveSearchNode<S> a, ExhaustiveSearchNode<S> b) {
         // Investigate deeper first
         int aDepth = a.getDepth();
         int bDepth = b.getDepth();

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/ScoreFirstNodeComparator.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/ScoreFirstNodeComparator.java
@@ -19,12 +19,14 @@ package org.optaplanner.core.impl.exhaustivesearch.node.comparator;
 import java.io.Serializable;
 import java.util.Comparator;
 
+import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.impl.exhaustivesearch.node.ExhaustiveSearchNode;
 
 /**
  * Investigate the nodes with a better optimistic bound first, then deeper nodes.
+ * @param <S> the score type
  */
-public class ScoreFirstNodeComparator implements Comparator<ExhaustiveSearchNode>, Serializable {
+public class ScoreFirstNodeComparator<S extends Score<S>> implements Comparator<ExhaustiveSearchNode<S>>, Serializable {
 
     public ScoreFirstNodeComparator(boolean scoreBounderEnabled) {
         if (!scoreBounderEnabled) {
@@ -34,7 +36,7 @@ public class ScoreFirstNodeComparator implements Comparator<ExhaustiveSearchNode
     }
 
     @Override
-    public int compare(ExhaustiveSearchNode a, ExhaustiveSearchNode b) {
+    public int compare(ExhaustiveSearchNode<S> a, ExhaustiveSearchNode<S> b) {
         // Investigate better score first (ignore initScore to avoid depth first ordering)
         int scoreComparison = a.getScore().toInitializedScore().compareTo(b.getScore().toInitializedScore());
         if (scoreComparison < 0) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/scope/ExhaustiveSearchPhaseScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/scope/ExhaustiveSearchPhaseScope.java
@@ -29,14 +29,15 @@ import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
+ * @param <Score_> the score type
  */
-public class ExhaustiveSearchPhaseScope<Solution_> extends AbstractPhaseScope<Solution_> {
+public class ExhaustiveSearchPhaseScope<Solution_, Score_ extends Score<Score_>> extends AbstractPhaseScope<Solution_> {
 
     private List<ExhaustiveSearchLayer> layerList;
-    private SortedSet<ExhaustiveSearchNode> expandableNodeQueue;
-    private Score bestPessimisticBound;
+    private SortedSet<ExhaustiveSearchNode<Score_>> expandableNodeQueue;
+    private Score_ bestPessimisticBound;
 
-    private ExhaustiveSearchStepScope<Solution_> lastCompletedStepScope;
+    private ExhaustiveSearchStepScope<Solution_, Score_> lastCompletedStepScope;
 
     public ExhaustiveSearchPhaseScope(DefaultSolverScope<Solution_> solverScope) {
         super(solverScope);
@@ -51,28 +52,28 @@ public class ExhaustiveSearchPhaseScope<Solution_> extends AbstractPhaseScope<So
         this.layerList = layerList;
     }
 
-    public SortedSet<ExhaustiveSearchNode> getExpandableNodeQueue() {
+    public SortedSet<ExhaustiveSearchNode<Score_>> getExpandableNodeQueue() {
         return expandableNodeQueue;
     }
 
-    public void setExpandableNodeQueue(SortedSet<ExhaustiveSearchNode> expandableNodeQueue) {
+    public void setExpandableNodeQueue(SortedSet<ExhaustiveSearchNode<Score_>> expandableNodeQueue) {
         this.expandableNodeQueue = expandableNodeQueue;
     }
 
-    public Score getBestPessimisticBound() {
+    public Score_ getBestPessimisticBound() {
         return bestPessimisticBound;
     }
 
-    public void setBestPessimisticBound(Score bestPessimisticBound) {
+    public void setBestPessimisticBound(Score_ bestPessimisticBound) {
         this.bestPessimisticBound = bestPessimisticBound;
     }
 
     @Override
-    public ExhaustiveSearchStepScope<Solution_> getLastCompletedStepScope() {
+    public ExhaustiveSearchStepScope<Solution_, Score_> getLastCompletedStepScope() {
         return lastCompletedStepScope;
     }
 
-    public void setLastCompletedStepScope(ExhaustiveSearchStepScope<Solution_> lastCompletedStepScope) {
+    public void setLastCompletedStepScope(ExhaustiveSearchStepScope<Solution_, Score_> lastCompletedStepScope) {
         this.lastCompletedStepScope = lastCompletedStepScope;
     }
 
@@ -85,13 +86,14 @@ public class ExhaustiveSearchPhaseScope<Solution_> extends AbstractPhaseScope<So
         return layerList.size();
     }
 
-    public void registerPessimisticBound(Score pessimisticBound) {
+    public void registerPessimisticBound(Score_ pessimisticBound) {
         if (pessimisticBound.compareTo(bestPessimisticBound) > 0) {
             bestPessimisticBound = pessimisticBound;
             // TODO optimize this because expandableNodeQueue is too long to iterate
-            for (Iterator<ExhaustiveSearchNode> iterator = expandableNodeQueue.iterator(); iterator.hasNext(); ) {
+            for (Iterator<ExhaustiveSearchNode<Score_>> iterator
+                    = expandableNodeQueue.iterator(); iterator.hasNext();) {
                 // Prune it
-                ExhaustiveSearchNode node = iterator.next();
+                ExhaustiveSearchNode<Score_> node = iterator.next();
                 if (node.getOptimisticBound().compareTo(bestPessimisticBound) <= 0) {
                     iterator.remove();
                 }
@@ -99,7 +101,7 @@ public class ExhaustiveSearchPhaseScope<Solution_> extends AbstractPhaseScope<So
         }
     }
 
-    public void addExpandableNode(ExhaustiveSearchNode moveNode) {
+    public void addExpandableNode(ExhaustiveSearchNode<Score_> moveNode) {
         expandableNodeQueue.add(moveNode);
         moveNode.setExpandable(true);
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/scope/ExhaustiveSearchStepScope.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/scope/ExhaustiveSearchStepScope.java
@@ -23,37 +23,38 @@ import org.optaplanner.core.impl.phase.scope.AbstractStepScope;
 
 /**
  * @param <Solution_> the solution type, the class with the {@link PlanningSolution} annotation
+ * @param <Score_> the score type
  */
-public class ExhaustiveSearchStepScope<Solution_> extends AbstractStepScope<Solution_> {
+public class ExhaustiveSearchStepScope<Solution_, Score_ extends Score<Score_>> extends AbstractStepScope<Solution_> {
 
-    private final ExhaustiveSearchPhaseScope<Solution_> phaseScope;
+    private final ExhaustiveSearchPhaseScope<Solution_, Score_> phaseScope;
 
-    private ExhaustiveSearchNode expandingNode;
+    private ExhaustiveSearchNode<Score_> expandingNode;
     private Long selectedMoveCount = null;
 
-    public ExhaustiveSearchStepScope(ExhaustiveSearchPhaseScope<Solution_> phaseScope) {
+    public ExhaustiveSearchStepScope(ExhaustiveSearchPhaseScope<Solution_, Score_> phaseScope) {
         this(phaseScope, phaseScope.getNextStepIndex());
     }
 
-    public ExhaustiveSearchStepScope(ExhaustiveSearchPhaseScope<Solution_> phaseScope, int stepIndex) {
+    public ExhaustiveSearchStepScope(ExhaustiveSearchPhaseScope<Solution_, Score_> phaseScope, int stepIndex) {
         super(stepIndex);
         this.phaseScope = phaseScope;
     }
 
     @Override
-    public ExhaustiveSearchPhaseScope<Solution_> getPhaseScope() {
+    public ExhaustiveSearchPhaseScope<Solution_, Score_> getPhaseScope() {
         return phaseScope;
     }
 
-    public ExhaustiveSearchNode getExpandingNode() {
+    public ExhaustiveSearchNode<Score_> getExpandingNode() {
         return expandingNode;
     }
 
-    public void setExpandingNode(ExhaustiveSearchNode expandingNode) {
+    public void setExpandingNode(ExhaustiveSearchNode<Score_> expandingNode) {
         this.expandingNode = expandingNode;
     }
 
-    public Score getStartingStepScore() {
+    public Score_ getStartingStepScore() {
         return expandingNode.getScore();
     }
 

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/DefaultExhaustiveSearchPhaseTest.java
@@ -52,10 +52,10 @@ public class DefaultExhaustiveSearchPhaseTest {
 
     @Test
     public void restoreWorkingSolution() {
-        ExhaustiveSearchPhaseScope<TestdataSolution> phaseScope = mock(ExhaustiveSearchPhaseScope.class);
-        ExhaustiveSearchStepScope<TestdataSolution> lastCompletedStepScope = mock(ExhaustiveSearchStepScope.class);
+        ExhaustiveSearchPhaseScope<TestdataSolution, SimpleScore> phaseScope = mock(ExhaustiveSearchPhaseScope.class);
+        ExhaustiveSearchStepScope<TestdataSolution, SimpleScore> lastCompletedStepScope = mock(ExhaustiveSearchStepScope.class);
         when(phaseScope.getLastCompletedStepScope()).thenReturn(lastCompletedStepScope);
-        ExhaustiveSearchStepScope<TestdataSolution> stepScope = mock(ExhaustiveSearchStepScope.class);
+        ExhaustiveSearchStepScope<TestdataSolution, SimpleScore> stepScope = mock(ExhaustiveSearchStepScope.class);
         when(stepScope.getPhaseScope()).thenReturn(phaseScope);
         TestdataSolution workingSolution = new TestdataSolution();
         when(phaseScope.getWorkingSolution()).thenReturn(workingSolution);
@@ -68,32 +68,32 @@ public class DefaultExhaustiveSearchPhaseTest {
         ExhaustiveSearchLayer layer2 = new ExhaustiveSearchLayer(2, mock(Object.class));
         ExhaustiveSearchLayer layer3 = new ExhaustiveSearchLayer(3, mock(Object.class));
         ExhaustiveSearchLayer layer4 = new ExhaustiveSearchLayer(4, mock(Object.class));
-        ExhaustiveSearchNode node0 = new ExhaustiveSearchNode(layer0, null);
+        ExhaustiveSearchNode<SimpleScore> node0 = new ExhaustiveSearchNode<>(layer0, null);
         node0.setMove(mock(Move.class));
         node0.setUndoMove(mock(Move.class));
-        ExhaustiveSearchNode node1 = new ExhaustiveSearchNode(layer1, node0);
+        ExhaustiveSearchNode<SimpleScore> node1 = new ExhaustiveSearchNode<>(layer1, node0);
         node1.setMove(mock(Move.class));
         node1.setUndoMove(mock(Move.class));
-        ExhaustiveSearchNode node2A = new ExhaustiveSearchNode(layer2, node1);
+        ExhaustiveSearchNode<SimpleScore> node2A = new ExhaustiveSearchNode<>(layer2, node1);
         node2A.setMove(mock(Move.class));
         node2A.setUndoMove(mock(Move.class));
-        ExhaustiveSearchNode node3A = new ExhaustiveSearchNode(layer3, node2A); // oldNode
+        ExhaustiveSearchNode<SimpleScore> node3A = new ExhaustiveSearchNode<>(layer3, node2A); // oldNode
         node3A.setMove(mock(Move.class));
         node3A.setUndoMove(mock(Move.class));
-        ExhaustiveSearchNode node2B = new ExhaustiveSearchNode(layer2, node1);
+        ExhaustiveSearchNode<SimpleScore> node2B = new ExhaustiveSearchNode<>(layer2, node1);
         node2B.setMove(mock(Move.class));
         node2B.setUndoMove(mock(Move.class));
-        ExhaustiveSearchNode node3B = new ExhaustiveSearchNode(layer3, node2B);
+        ExhaustiveSearchNode<SimpleScore> node3B = new ExhaustiveSearchNode<>(layer3, node2B);
         node3B.setMove(mock(Move.class));
         node3B.setUndoMove(mock(Move.class));
-        ExhaustiveSearchNode node4B = new ExhaustiveSearchNode(layer4, node3B); // newNode
+        ExhaustiveSearchNode<SimpleScore> node4B = new ExhaustiveSearchNode<>(layer4, node3B); // newNode
         node4B.setMove(mock(Move.class));
         node4B.setUndoMove(mock(Move.class));
         node4B.setScore(SimpleScore.valueOf(-96, 7));
         when(lastCompletedStepScope.getExpandingNode()).thenReturn(node3A);
         when(stepScope.getExpandingNode()).thenReturn(node4B);
 
-        DefaultExhaustiveSearchPhase<TestdataSolution> phase = new DefaultExhaustiveSearchPhase<>(0, "", null, null);
+        DefaultExhaustiveSearchPhase<TestdataSolution, SimpleScore> phase = new DefaultExhaustiveSearchPhase<>(0, "", null, null);
         phase.setEntitySelector(mock(EntitySelector.class));
         phase.setDecider(mock(ExhaustiveSearchDecider.class));
         phase.restoreWorkingSolution(stepScope);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/AbstractNodeComparatorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/AbstractNodeComparatorTest.java
@@ -18,6 +18,7 @@ package org.optaplanner.core.impl.exhaustivesearch.node.comparator;
 
 import java.util.Comparator;
 
+import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 import org.optaplanner.core.impl.exhaustivesearch.node.ExhaustiveSearchNode;
 
@@ -26,14 +27,14 @@ import static org.mockito.Mockito.*;
 
 public abstract class AbstractNodeComparatorTest {
 
-    protected ExhaustiveSearchNode buildNode(int depth, String score, long parentBreadth, long breadth) {
+    protected ExhaustiveSearchNode<SimpleScore> buildNode(int depth, String score, long parentBreadth, long breadth) {
         return buildNode(depth,
                 SimpleScore.parseScore(score),
                 SimpleScore.parseScore(score).toInitializedScore(),
                 parentBreadth, breadth);
     }
 
-    protected ExhaustiveSearchNode buildNode(int depth, String score, int optimisticBound,
+    protected ExhaustiveSearchNode<SimpleScore> buildNode(int depth, String score, int optimisticBound,
             long parentBreadth, long breadth) {
         return buildNode(depth,
                 SimpleScore.parseScore(score),
@@ -41,9 +42,9 @@ public abstract class AbstractNodeComparatorTest {
                 parentBreadth, breadth);
     }
 
-    protected ExhaustiveSearchNode buildNode(int depth, SimpleScore score, SimpleScore optimisticBound,
+    protected <S extends Score<S>> ExhaustiveSearchNode<S> buildNode(int depth, S score, S optimisticBound,
             long parentBreadth, long breadth) {
-        ExhaustiveSearchNode node = mock(ExhaustiveSearchNode.class);
+        ExhaustiveSearchNode<S> node = mock(ExhaustiveSearchNode.class);
         when(node.getDepth()).thenReturn(depth);
         when(node.getScore()).thenReturn(score);
         when(node.getOptimisticBound()).thenReturn(optimisticBound);
@@ -53,14 +54,15 @@ public abstract class AbstractNodeComparatorTest {
         return node;
     }
 
-    protected static void assertLesser(Comparator<ExhaustiveSearchNode> comparator,
-            ExhaustiveSearchNode a, ExhaustiveSearchNode b) {
+    protected static <S extends Score<S>> void assertLesser(Comparator<ExhaustiveSearchNode<S>> comparator,
+            ExhaustiveSearchNode<S> a, ExhaustiveSearchNode<S> b) {
         assertTrue("Node (" + a + ") must be lesser than node (" + b + ").", comparator.compare(a, b) < 0);
         assertTrue("Node (" + b + ") must be greater than node (" + a + ").", comparator.compare(b, a) > 0);
     }
 
-    protected static void assertScoreCompareToOrder(Comparator<ExhaustiveSearchNode> comparator,
-            ExhaustiveSearchNode... nodes) {
+    @SafeVarargs
+    protected static <S extends Score<S>> void assertScoreCompareToOrder(Comparator<ExhaustiveSearchNode<S>> comparator,
+            ExhaustiveSearchNode<S>... nodes) {
         for (int i = 0; i < nodes.length; i++) {
             for (int j = i + 1; j < nodes.length; j++) {
                 assertLesser(comparator, nodes[i], nodes[j]);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/BreadthFirstNodeComparatorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/BreadthFirstNodeComparatorTest.java
@@ -17,12 +17,13 @@
 package org.optaplanner.core.impl.exhaustivesearch.node.comparator;
 
 import org.junit.Test;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 
 public class BreadthFirstNodeComparatorTest extends AbstractNodeComparatorTest {
 
     @Test
     public void compare() {
-        BreadthFirstNodeComparator comparator = new BreadthFirstNodeComparator(true);
+        BreadthFirstNodeComparator<SimpleScore> comparator = new BreadthFirstNodeComparator<>(true);
         assertScoreCompareToOrder(comparator,
                 buildNode(2, "-110", 5, 51),
                 buildNode(2, "-110", 5, 50),

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/DepthFirstNodeComparatorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/DepthFirstNodeComparatorTest.java
@@ -17,12 +17,13 @@
 package org.optaplanner.core.impl.exhaustivesearch.node.comparator;
 
 import org.junit.Test;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 
 public class DepthFirstNodeComparatorTest extends AbstractNodeComparatorTest {
 
     @Test
     public void compare() {
-        DepthFirstNodeComparator comparator = new DepthFirstNodeComparator(true);
+        DepthFirstNodeComparator<SimpleScore> comparator = new DepthFirstNodeComparator<>(true);
         assertScoreCompareToOrder(comparator,
                 buildNode(1, "-110", 5, 41),
                 buildNode(1, "-110", 5, 40),

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/OptimisticBoundFirstNodeComparatorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/OptimisticBoundFirstNodeComparatorTest.java
@@ -17,12 +17,13 @@
 package org.optaplanner.core.impl.exhaustivesearch.node.comparator;
 
 import org.junit.Test;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 
 public class OptimisticBoundFirstNodeComparatorTest extends AbstractNodeComparatorTest {
 
     @Test
     public void compare() {
-        OptimisticBoundFirstNodeComparator comparator = new OptimisticBoundFirstNodeComparator(true);
+        OptimisticBoundFirstNodeComparator<SimpleScore> comparator = new OptimisticBoundFirstNodeComparator<>(true);
         assertScoreCompareToOrder(comparator,
                 buildNode(1, "-300", 5, 41),
                 buildNode(1, "-300", 5, 40),

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/ScoreFirstNodeComparatorTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/node/comparator/ScoreFirstNodeComparatorTest.java
@@ -17,12 +17,13 @@
 package org.optaplanner.core.impl.exhaustivesearch.node.comparator;
 
 import org.junit.Test;
+import org.optaplanner.core.api.score.buildin.simple.SimpleScore;
 
 public class ScoreFirstNodeComparatorTest extends AbstractNodeComparatorTest {
 
     @Test
     public void compare() {
-        ScoreFirstNodeComparator comparator = new ScoreFirstNodeComparator(true);
+        ScoreFirstNodeComparator<SimpleScore> comparator = new ScoreFirstNodeComparator<>(true);
         assertScoreCompareToOrder(comparator,
                 buildNode(1, "-110", 5, 41),
                 buildNode(1, "-110", 5, 40),

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/scope/ExhaustiveSearchPhaseScopeTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/exhaustivesearch/scope/ExhaustiveSearchPhaseScopeTest.java
@@ -30,9 +30,9 @@ public class ExhaustiveSearchPhaseScopeTest extends AbstractNodeComparatorTest {
 
     @Test
     public void testNodePruning() {
-        ExhaustiveSearchPhaseScope<TestdataSolution> phase
-                = new ExhaustiveSearchPhaseScope<TestdataSolution>(new DefaultSolverScope<TestdataSolution>());
-        phase.setExpandableNodeQueue(new TreeSet<>(new ScoreFirstNodeComparator(true)));
+        ExhaustiveSearchPhaseScope<TestdataSolution, SimpleScore> phase
+                = new ExhaustiveSearchPhaseScope<>(new DefaultSolverScope<TestdataSolution>());
+        phase.setExpandableNodeQueue(new TreeSet<>(new ScoreFirstNodeComparator<>(true)));
         phase.addExpandableNode(buildNode(0, "0", 0, 0));
         phase.addExpandableNode(buildNode(0, "1", 0, 0));
         phase.addExpandableNode(buildNode(0, "2", 0, 0));


### PR DESCRIPTION
Using the score type parameter allows safe ES node comparison and calculation of optimistic and pessimistic bounds.

Compiler warnings reduced by 28.