### PR TITLE
Eliminate some warnings related to Move<Solution_>

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/constructionheuristic/DefaultConstructionHeuristicPhase.java
@@ -103,7 +103,7 @@ public class DefaultConstructionHeuristicPhase<Solution_> extends AbstractPhase<
     }
 
     private void doStep(ConstructionHeuristicStepScope<Solution_> stepScope) {
-        Move nextStep = stepScope.getStep();
+        Move<Solution_> nextStep = stepScope.getStep();
         nextStep.doMove(stepScope.getScoreDirector());
         predictWorkingStepScore(stepScope, nextStep);
         if (!skipBestSolutionCloningInSteps) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/decider/ExhaustiveSearchDecider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/exhaustivesearch/decider/ExhaustiveSearchDecider.java
@@ -27,7 +27,6 @@ import org.optaplanner.core.impl.heuristic.move.Move;
 import org.optaplanner.core.impl.heuristic.selector.entity.mimic.ManualEntityMimicRecorder;
 import org.optaplanner.core.impl.heuristic.selector.move.MoveSelector;
 import org.optaplanner.core.impl.score.director.InnerScoreDirector;
-import org.optaplanner.core.impl.score.director.ScoreDirector;
 import org.optaplanner.core.impl.solver.recaller.BestSolutionRecaller;
 import org.optaplanner.core.impl.solver.scope.DefaultSolverScope;
 import org.optaplanner.core.impl.solver.termination.Termination;
@@ -127,7 +126,7 @@ public class ExhaustiveSearchDecider<Solution_> implements ExhaustiveSearchPhase
 
         int moveIndex = 0;
         ExhaustiveSearchLayer moveLayer = stepScope.getPhaseScope().getLayerList().get(expandingNode.getDepth() + 1);
-        for (Move move : moveSelector) {
+        for (Move<?> move : moveSelector) {
             ExhaustiveSearchNode moveNode = new ExhaustiveSearchNode(moveLayer, expandingNode);
             moveIndex++;
             moveNode.setMove(move);
@@ -145,9 +144,9 @@ public class ExhaustiveSearchDecider<Solution_> implements ExhaustiveSearchPhase
     }
 
     private void doMove(ExhaustiveSearchStepScope<Solution_> stepScope, ExhaustiveSearchNode moveNode) {
-        ScoreDirector scoreDirector = stepScope.getScoreDirector();
-        Move move = moveNode.getMove();
-        Move undoMove = move.createUndoMove(scoreDirector);
+        InnerScoreDirector<Solution_> scoreDirector = stepScope.getScoreDirector();
+        Move<Solution_> move = moveNode.getMove();
+        Move<Solution_> undoMove = move.createUndoMove(scoreDirector);
         moveNode.setUndoMove(undoMove);
         move.doMove(scoreDirector);
         processMove(stepScope, moveNode);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/move/CompositeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/move/CompositeMove.java
@@ -159,7 +159,7 @@ public class CompositeMove<Solution_> implements Move<Solution_> {
         if (this == o) {
             return true;
         } else if (o instanceof CompositeMove) {
-            CompositeMove other = (CompositeMove) o;
+            CompositeMove<?> other = (CompositeMove) o;
             return Arrays.equals(moves, other.moves);
         } else {
             return false;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/move/NoChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/move/NoChangeMove.java
@@ -35,7 +35,7 @@ public class NoChangeMove<Solution_> extends AbstractMove<Solution_> {
 
     @Override
     public NoChangeMove<Solution_> createUndoMove(ScoreDirector<Solution_> scoreDirector) {
-        return new NoChangeMove();
+        return new NoChangeMove<>();
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/ChangeMove.java
@@ -102,7 +102,7 @@ public class ChangeMove<Solution_> extends AbstractMove<Solution_> {
         if (this == o) {
             return true;
         } else if (o instanceof ChangeMove) {
-            ChangeMove other = (ChangeMove) o;
+            ChangeMove<?> other = (ChangeMove) o;
             return new EqualsBuilder()
                     .append(entity, other.entity)
                     .append(variableDescriptor, other.variableDescriptor)

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarChangeMove.java
@@ -123,7 +123,7 @@ public class PillarChangeMove<Solution_> extends AbstractMove<Solution_> {
         if (this == o) {
             return true;
         } else if (o instanceof PillarChangeMove) {
-            PillarChangeMove other = (PillarChangeMove) o;
+            PillarChangeMove<?> other = (PillarChangeMove) o;
             return new EqualsBuilder()
                     .append(variableDescriptor, other.variableDescriptor)
                     .append(pillar, other.pillar)

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarSwapMove.java
@@ -133,7 +133,7 @@ public class PillarSwapMove<Solution_> extends AbstractMove<Solution_> {
         StringBuilder moveTypeDescription = new StringBuilder(20 * (variableDescriptorList.size() + 1));
         moveTypeDescription.append(getClass().getSimpleName()).append("(");
         String delimiter = "";
-        for (GenuineVariableDescriptor variableDescriptor : variableDescriptorList) {
+        for (GenuineVariableDescriptor<Solution_> variableDescriptor : variableDescriptorList) {
             moveTypeDescription.append(delimiter).append(variableDescriptor.getSimpleEntityAndVariableName());
             delimiter = ", ";
         }
@@ -153,7 +153,7 @@ public class PillarSwapMove<Solution_> extends AbstractMove<Solution_> {
     @Override
     public Collection<? extends Object> getPlanningValues() {
         List<Object> values = new ArrayList<>(variableDescriptorList.size() * 2);
-        for (GenuineVariableDescriptor variableDescriptor : variableDescriptorList) {
+        for (GenuineVariableDescriptor<Solution_> variableDescriptor : variableDescriptorList) {
             values.add(variableDescriptor.getValue(leftPillar.get(0)));
             values.add(variableDescriptor.getValue(rightPillar.get(0)));
         }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/PillarSwapMove.java
@@ -164,7 +164,7 @@ public class PillarSwapMove<Solution_> extends AbstractMove<Solution_> {
         if (this == o) {
             return true;
         } else if (o instanceof PillarSwapMove) {
-            PillarSwapMove other = (PillarSwapMove) o;
+            PillarSwapMove<?> other = (PillarSwapMove) o;
             return new EqualsBuilder()
                     .append(variableDescriptorList, other.variableDescriptorList)
                     .append(leftPillar, other.leftPillar)

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMove.java
@@ -124,7 +124,7 @@ public class SwapMove<Solution_> extends AbstractMove<Solution_> {
         StringBuilder moveTypeDescription = new StringBuilder(20 * (variableDescriptorList.size() + 1));
         moveTypeDescription.append(getClass().getSimpleName()).append("(");
         String delimiter = "";
-        for (GenuineVariableDescriptor variableDescriptor : variableDescriptorList) {
+        for (GenuineVariableDescriptor<Solution_> variableDescriptor : variableDescriptorList) {
             moveTypeDescription.append(delimiter).append(variableDescriptor.getSimpleEntityAndVariableName());
             delimiter = ", ";
         }
@@ -140,7 +140,7 @@ public class SwapMove<Solution_> extends AbstractMove<Solution_> {
     @Override
     public Collection<? extends Object> getPlanningValues() {
         List<Object> values = new ArrayList<>(variableDescriptorList.size() * 2);
-        for (GenuineVariableDescriptor variableDescriptor : variableDescriptorList) {
+        for (GenuineVariableDescriptor<Solution_> variableDescriptor : variableDescriptorList) {
             values.add(variableDescriptor.getValue(leftEntity));
             values.add(variableDescriptor.getValue(rightEntity));
         }
@@ -181,7 +181,7 @@ public class SwapMove<Solution_> extends AbstractMove<Solution_> {
 
     protected void appendVariablesToString(StringBuilder s, Object entity) {
         boolean first = true;
-        for (GenuineVariableDescriptor variableDescriptor : variableDescriptorList) {
+        for (GenuineVariableDescriptor<Solution_> variableDescriptor : variableDescriptorList) {
             if (!first) {
                 s.append(", ");
             }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/SwapMove.java
@@ -151,7 +151,7 @@ public class SwapMove<Solution_> extends AbstractMove<Solution_> {
         if (this == o) {
             return true;
         } else if (o instanceof SwapMove) {
-            SwapMove other = (SwapMove) o;
+            SwapMove<?> other = (SwapMove) o;
             return new EqualsBuilder()
                     .append(leftEntity, other.leftEntity)
                     .append(rightEntity, other.rightEntity)

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/KOptMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/KOptMove.java
@@ -167,7 +167,7 @@ public class KOptMove<Solution_> extends AbstractMove<Solution_> {
         if (this == o) {
             return true;
         } else if (o instanceof KOptMove) {
-            KOptMove other = (KOptMove) o;
+            KOptMove<?> other = (KOptMove) o;
             return new EqualsBuilder()
                     .append(entity, other.entity)
                     .append(values, other.values)

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainChangeMove.java
@@ -122,7 +122,7 @@ public class SubChainChangeMove<Solution_> extends AbstractMove<Solution_> {
         if (this == o) {
             return true;
         } else if (o instanceof SubChainChangeMove) {
-            SubChainChangeMove other = (SubChainChangeMove) o;
+            SubChainChangeMove<?> other = (SubChainChangeMove) o;
             return new EqualsBuilder()
                     .append(subChain, other.subChain)
                     .append(variableDescriptor, other.variableDescriptor)

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingChangeMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingChangeMove.java
@@ -143,7 +143,7 @@ public class SubChainReversingChangeMove<Solution_> extends AbstractMove<Solutio
         if (this == o) {
             return true;
         } else if (o instanceof SubChainReversingChangeMove) {
-            SubChainReversingChangeMove other = (SubChainReversingChangeMove) o;
+            SubChainReversingChangeMove<?> other = (SubChainReversingChangeMove) o;
             return new EqualsBuilder()
                     .append(subChain, other.subChain)
                     .append(variableDescriptor.getVariableName(),

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainReversingSwapMove.java
@@ -157,7 +157,7 @@ public class SubChainReversingSwapMove<Solution_> extends AbstractMove<Solution_
         if (this == o) {
             return true;
         } else if (o instanceof SubChainReversingSwapMove) {
-            SubChainReversingSwapMove other = (SubChainReversingSwapMove) o;
+            SubChainReversingSwapMove<?> other = (SubChainReversingSwapMove) o;
             return new EqualsBuilder()
                     .append(variableDescriptor, other.variableDescriptor)
                     .append(leftSubChain, other.leftSubChain)

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/SubChainSwapMove.java
@@ -147,7 +147,7 @@ public class SubChainSwapMove<Solution_> extends AbstractMove<Solution_> {
         if (this == o) {
             return true;
         } else if (o instanceof SubChainSwapMove) {
-            SubChainSwapMove other = (SubChainSwapMove) o;
+            SubChainSwapMove<?> other = (SubChainSwapMove) o;
             return new EqualsBuilder()
                     .append(variableDescriptor, other.variableDescriptor)
                     .append(leftSubChain, other.leftSubChain)

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/TailChainSwapMove.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/heuristic/selector/move/generic/chained/TailChainSwapMove.java
@@ -217,7 +217,7 @@ public class TailChainSwapMove<Solution_> extends AbstractMove<Solution_> {
         if (this == o) {
             return true;
         } else if (o instanceof TailChainSwapMove) {
-            TailChainSwapMove other = (TailChainSwapMove) o;
+            TailChainSwapMove<?> other = (TailChainSwapMove) o;
             return new EqualsBuilder()
                     .append(leftEntity, other.leftEntity)
                     .append(rightValue, other.rightValue)

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/DefaultLocalSearchPhase.java
@@ -97,7 +97,7 @@ public class DefaultLocalSearchPhase<Solution_> extends AbstractPhase<Solution_>
     }
 
     protected void doStep(LocalSearchStepScope<Solution_> stepScope) {
-        Move nextStep = stepScope.getStep();
+        Move<Solution_> nextStep = stepScope.getStep();
         nextStep.doMove(stepScope.getScoreDirector());
         predictWorkingStepScore(stepScope, nextStep);
         bestSolutionRecaller.processWorkingSolutionDuringStep(stepScope);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/LocalSearchDecider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/LocalSearchDecider.java
@@ -104,10 +104,10 @@ public class LocalSearchDecider<Solution_> {
     }
 
     public void decideNextStep(LocalSearchStepScope<Solution_> stepScope) {
-        InnerScoreDirector scoreDirector = stepScope.getScoreDirector();
+        InnerScoreDirector<Solution_> scoreDirector = stepScope.getScoreDirector();
         scoreDirector.setAllChangesWillBeUndoneBeforeStepEnds(true);
         int moveIndex = 0;
-        for (Move move : moveSelector) {
+        for (Move<Solution_> move : moveSelector) {
             LocalSearchMoveScope<Solution_> moveScope = new LocalSearchMoveScope<>(stepScope);
             moveScope.setMoveIndex(moveIndex);
             moveIndex++;
@@ -130,7 +130,7 @@ public class LocalSearchDecider<Solution_> {
         scoreDirector.setAllChangesWillBeUndoneBeforeStepEnds(false);
         LocalSearchMoveScope<Solution_> pickedMoveScope = forager.pickMove(stepScope);
         if (pickedMoveScope != null) {
-            Move step = pickedMoveScope.getMove();
+            Move<?> step = pickedMoveScope.getMove();
             stepScope.setStep(step);
             if (logger.isDebugEnabled()) {
                 stepScope.setStepString(step.toString());
@@ -141,9 +141,9 @@ public class LocalSearchDecider<Solution_> {
     }
 
     private void doMove(LocalSearchMoveScope<Solution_> moveScope) {
-        ScoreDirector scoreDirector = moveScope.getScoreDirector();
-        Move move = moveScope.getMove();
-        Move undoMove = move.createUndoMove(scoreDirector);
+        ScoreDirector<Solution_> scoreDirector = moveScope.getScoreDirector();
+        Move<Solution_> move = moveScope.getMove();
+        Move<Solution_> undoMove = move.createUndoMove(scoreDirector);
         moveScope.setUndoMove(undoMove);
         move.doMove(scoreDirector);
         processMove(moveScope);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/MoveTabuAcceptor.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/localsearch/decider/acceptor/tabu/MoveTabuAcceptor.java
@@ -46,7 +46,7 @@ public class MoveTabuAcceptor extends AbstractTabuAcceptor {
 
     @Override
     protected Collection<? extends Object> findNewTabu(LocalSearchStepScope stepScope) {
-        Move tabuMove;
+        Move<?> tabuMove;
         if (useUndoMoveAsTabuMove) {
             tabuMove = stepScope.getUndoStep();
         } else {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/partitionedsearch/DefaultPartitionedSearchPhase.java
@@ -171,7 +171,7 @@ public class DefaultPartitionedSearchPhase<Solution_> extends AbstractPhase<Solu
     }
 
     protected void doStep(PartitionedSearchStepScope<Solution_> stepScope) {
-        Move nextStep = stepScope.getStep();
+        Move<Solution_> nextStep = stepScope.getStep();
         nextStep.doMove(stepScope.getScoreDirector());
         calculateWorkingStepScore(stepScope, nextStep);
         bestSolutionRecaller.processWorkingSolutionDuringStep(stepScope);

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedEntityPlacerTest.java
@@ -192,7 +192,7 @@ public class QueuedEntityPlacerTest {
         assertNotNull(iterator);
         for (String valueCode : valueCodes) {
             assertTrue(iterator.hasNext());
-            ChangeMove move = (ChangeMove) iterator.next();
+            ChangeMove<?> move = (ChangeMove) iterator.next();
             assertCode(entityCode, move.getEntity());
             assertCode(valueCode, move.getToPlanningValue());
         }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/constructionheuristic/placer/entity/QueuedValuePlacerTest.java
@@ -120,7 +120,7 @@ public class QueuedValuePlacerTest {
         assertNotNull(iterator);
         for (String entityCode : entityCodes) {
             assertTrue(iterator.hasNext());
-            ChangeMove move = (ChangeMove) iterator.next();
+            ChangeMove<?> move = (ChangeMove) iterator.next();
             assertCode(entityCode, move.getEntity());
             assertCode(valueCode, move.getToPlanningValue());
         }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/move/DummyMove.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/move/DummyMove.java
@@ -20,9 +20,10 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaplanner.core.impl.testdata.domain.TestdataSolution;
 import org.optaplanner.core.impl.testdata.util.CodeAssertable;
 
-public class DummyMove extends AbstractMove<Object> implements CodeAssertable {
+public class DummyMove extends AbstractMove<TestdataSolution> implements CodeAssertable {
 
     protected String code;
 
@@ -43,28 +44,28 @@ public class DummyMove extends AbstractMove<Object> implements CodeAssertable {
     // ************************************************************************
 
     @Override
-    public boolean isMoveDoable(ScoreDirector<Object> scoreDirector) {
+    public boolean isMoveDoable(ScoreDirector<TestdataSolution> scoreDirector) {
         return true;
     }
 
     @Override
-    public DummyMove createUndoMove(ScoreDirector<Object> scoreDirector) {
+    public DummyMove createUndoMove(ScoreDirector<TestdataSolution> scoreDirector) {
         return new DummyMove("undo " + code);
     }
 
     @Override
-    protected void doMoveOnGenuineVariables(ScoreDirector<Object> scoreDirector) {
+    protected void doMoveOnGenuineVariables(ScoreDirector<TestdataSolution> scoreDirector) {
         // do nothing
     }
 
     @Override
-    public Collection<? extends Object> getPlanningEntities() {
-        return Collections.<Object>emptyList();
+    public Collection<? extends TestdataSolution> getPlanningEntities() {
+        return Collections.<TestdataSolution>emptyList();
     }
 
     @Override
-    public Collection<? extends Object> getPlanningValues() {
-        return Collections.<Object>emptyList();
+    public Collection<? extends TestdataSolution> getPlanningValues() {
+        return Collections.<TestdataSolution>emptyList();
     }
 
     @Override

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/move/NoChangeMoveTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/heuristic/move/NoChangeMoveTest.java
@@ -25,22 +25,22 @@ public class NoChangeMoveTest {
 
     @Test
     public void isMoveDoable() {
-        assertEquals(true, new NoChangeMove().isMoveDoable(null));
+        assertEquals(true, new NoChangeMove<>().isMoveDoable(null));
     }
 
     @Test
     public void createUndoMove() {
-        assertInstanceOf(NoChangeMove.class, new NoChangeMove().createUndoMove(null));
+        assertInstanceOf(NoChangeMove.class, new NoChangeMove<>().createUndoMove(null));
     }
 
     @Test
     public void getPlanningEntities() {
-        assertEquals(true, new NoChangeMove().getPlanningEntities().isEmpty());
+        assertEquals(true, new NoChangeMove<>().getPlanningEntities().isEmpty());
     }
 
     @Test
     public void getPlanningValues() {
-        assertEquals(true, new NoChangeMove().getPlanningValues().isEmpty());
+        assertEquals(true, new NoChangeMove<>().getPlanningValues().isEmpty());
     }
 
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/util/PlannerAssert.java
@@ -218,7 +218,7 @@ public class PlannerAssert extends Assert {
         if (o instanceof CodeAssertable) {
             return (CodeAssertable) o;
         } else if (o instanceof ChangeMove) {
-            ChangeMove changeMove = (ChangeMove) o;
+            ChangeMove<?> changeMove = (ChangeMove) o;
             final String code = convertToCodeAssertable(changeMove.getEntity()).getCode()
                     + "->" + convertToCodeAssertable(changeMove.getToPlanningValue()).getCode();
             return () -> code;
@@ -228,9 +228,9 @@ public class PlannerAssert extends Assert {
                     + "<->" + convertToCodeAssertable(swapMove.getRightEntity()).getCode();
             return () -> code;
         } else if (o instanceof CompositeMove) {
-            CompositeMove compositeMove = (CompositeMove) o;
+            CompositeMove<?> compositeMove = (CompositeMove) o;
             StringBuilder codeBuilder = new StringBuilder(compositeMove.getMoves().length * 80);
-            for (Move move : compositeMove.getMoves()) {
+            for (Move<?> move : compositeMove.getMoves()) {
                 codeBuilder.append("+").append(convertToCodeAssertable(move).getCode());
             }
             final String code = codeBuilder.substring(1);


### PR DESCRIPTION
I was reviewing https://issues.jboss.org/browse/PLANNER-731 and I found some rawtype Moves usages that could be easily fixed without side effects like changing method signatures and cascading to other parts of the code. Using the Solution_ parameter where possible also eliminated a number of unchecked warnings.