### PR TITLE
Make TestGen compatible with Coach Shuttle Gathering example

### DIFF
--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenDroolsScoreDirector.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenDroolsScoreDirector.java
@@ -93,6 +93,27 @@ public class TestGenDroolsScoreDirector<Solution_> extends DroolsScoreDirector<S
     }
 
     @Override
+    public void assertShadowVariablesAreNotStale(Score expectedWorkingScore, Object completedAction) {
+        try {
+            super.assertShadowVariablesAreNotStale(expectedWorkingScore, completedAction);
+        } catch (IllegalStateException e) {
+            // catch stale shadow variable exception and create a minimal reproducing test
+            // TODO check it's really stale shadow variable?
+//            TestGenCorruptedScoreReproducer reproducer = new TestGenCorruptedScoreReproducer(e.getMessage(), this);
+//            TestGenKieSessionJournal minJournal = TestGenerator.minimize(journal, reproducer);
+            try {
+//                minJournal.replay(createKieSession());
+//                throw new IllegalStateException();
+            } catch (TestGenCorruptedScoreException tgcse) {
+                writer.setCorruptedScoreException(tgcse);
+            }
+//            writer.print(minJournal, testFile);
+            writer.print(journal, testFile);
+            throw wrapOriginalException(e);
+        }
+    }
+
+    @Override
     public void assertWorkingScoreFromScratch(Score workingScore, Object completedAction) {
         try {
             super.assertWorkingScoreFromScratch(workingScore, completedAction);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionEventSupport.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionEventSupport.java
@@ -16,14 +16,17 @@
 package org.optaplanner.core.impl.score.director.drools.testgen;
 
 import org.kie.api.runtime.KieSession;
+import org.optaplanner.core.impl.score.director.drools.testgen.operation.TestGenKieSessionFireAllRules;
 import org.optaplanner.core.impl.solver.event.AbstractEventSupport;
 
-public class TestGenKieSessionEventSupport extends AbstractEventSupport<TestGenKieSessionListener> implements TestGenKieSessionListener {
+public class TestGenKieSessionEventSupport extends AbstractEventSupport<TestGenKieSessionListener>
+        implements TestGenKieSessionListener {
 
     @Override
-    public void afterFireAllRules(KieSession kieSession, TestGenKieSessionJournal journal) {
+    public void afterFireAllRules(KieSession kieSession, TestGenKieSessionJournal journal,
+            TestGenKieSessionFireAllRules fire) {
         for (TestGenKieSessionListener listener : eventListenerSet) {
-            listener.afterFireAllRules(kieSession, journal);
+            listener.afterFireAllRules(kieSession, journal, fire);
         }
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionJournal.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionJournal.java
@@ -115,7 +115,7 @@ public class TestGenKieSessionJournal {
                     + "[" + entity + "]) is not a working fact");
         }
         Object value = variableDescriptor.getValue(entity);
-        TestGenFact valueFact = value == null ? new TestGenNullFact() : existingInstances.get(value);
+        TestGenFact valueFact = value == null ? TestGenNullFact.INSTANCE : existingInstances.get(value);
         if (valueFact == null) {
             // shadow variable
             if (logger.isTraceEnabled()) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionJournal.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionJournal.java
@@ -43,6 +43,7 @@ public class TestGenKieSessionJournal {
     private final List<TestGenKieSessionInsert> initialInsertJournal;
     private final List<TestGenKieSessionOperation> updateJournal;
     private int operationId = 0;
+    private boolean assertMode = false;
 
     public TestGenKieSessionJournal() {
         facts = new ArrayList<>();
@@ -73,7 +74,7 @@ public class TestGenKieSessionJournal {
                 op.invoke(replayKieSession);
                 // detect corrupted score after firing rules
                 if (op.getClass().equals(TestGenKieSessionFireAllRules.class)) {
-                    eventSupport.afterFireAllRules(replayKieSession, this);
+                    eventSupport.afterFireAllRules(replayKieSession, this, (TestGenKieSessionFireAllRules) op);
                 }
             }
         } finally {
@@ -135,7 +136,8 @@ public class TestGenKieSessionJournal {
     }
 
     public void fireAllRules() {
-        updateJournal.add(new TestGenKieSessionFireAllRules(operationId++));
+        TestGenKieSessionFireAllRules fire = new TestGenKieSessionFireAllRules(operationId++, assertMode);
+        updateJournal.add(fire);
     }
 
     public void dispose() {
@@ -144,6 +146,14 @@ public class TestGenKieSessionJournal {
         initialInsertJournal.clear();
         updateJournal.clear();
         operationId = 0;
+    }
+
+    void enterAssertMode() {
+        assertMode = true;
+    }
+
+    void exitAssertMode() {
+        assertMode = false;
     }
 
     //------------------------------------------------------------------------------------------------------------------

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionJournal.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionJournal.java
@@ -119,11 +119,6 @@ public class TestGenKieSessionJournal {
         TestGenFact valueFact = value == null ? TestGenNullFact.INSTANCE : existingInstances.get(value);
         if (valueFact == null) {
             // shadow variable
-            if (logger.isTraceEnabled()) {
-                logger.trace("Updating shadow variable {}.{} → {}({})", entity.getClass().getSimpleName(),
-                        variableDescriptor.getVariableName(),
-                        value.getClass().getSimpleName(), value);
-            }
             valueFact = new TestGenInlineValue(value, existingInstances);
         }
         updateJournal.add(new TestGenKieSessionUpdate(operationId++, entityFact, variableDescriptor, valueFact));
@@ -137,6 +132,7 @@ public class TestGenKieSessionJournal {
 
     public void fireAllRules() {
         TestGenKieSessionFireAllRules fire = new TestGenKieSessionFireAllRules(operationId++, assertMode);
+        logger.trace("        FIRE ALL RULES ({})", fire);
         updateJournal.add(fire);
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionListener.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenKieSessionListener.java
@@ -18,8 +18,9 @@ package org.optaplanner.core.impl.score.director.drools.testgen;
 import java.util.EventListener;
 
 import org.kie.api.runtime.KieSession;
+import org.optaplanner.core.impl.score.director.drools.testgen.operation.TestGenKieSessionFireAllRules;
 
 public interface TestGenKieSessionListener extends EventListener {
 
-    void afterFireAllRules(KieSession kieSession, TestGenKieSessionJournal journal);
+    void afterFireAllRules(KieSession kieSession, TestGenKieSessionJournal journal, TestGenKieSessionFireAllRules fire);
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenFactField.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenFactField.java
@@ -57,8 +57,11 @@ public class TestGenFactField implements Comparable<TestGenFactField> {
 
     void print(StringBuilder sb) {
         if (active) {
-            Method setter = ReflectionHelper.getSetterMethod(
-                    fact.getInstance().getClass(), accessor.getType(), accessor.getName());
+            Method setter = ReflectionHelper.getSetterMethod(fact.getInstance().getClass(), accessor.getName());
+            if (setter == null) {
+                throw new IllegalStateException("Setter for '" + fact.getInstance().getClass().getSimpleName() + "."
+                        + accessor.getName() + "' not found!");
+            }
             valueProvider.printSetup(sb);
             // null original value means the field is uninitialized so there's no need to .set(null);
             if (valueProvider.get() != null) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenInlineListValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenInlineListValueProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,29 +15,22 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-class TestGenListValueProvider extends TestGenAbstractValueProvider<List<?>> {
+class TestGenInlineListValueProvider extends TestGenAbstractValueProvider<List<?>> {
 
-    private final String identifier;
-    private final Type typeArgument;
     private final Map<Object, TestGenFact> existingInstances;
-    private final List<Class<?>> imports = new ArrayList<>();
     private final List<TestGenFact> requiredFacts;
 
-    public TestGenListValueProvider(List<?> value, String identifier, Type genericType,
-            Map<Object, TestGenFact> existingInstances) {
+    public TestGenInlineListValueProvider(List<?> value, Map<Object, TestGenFact> existingInstances) {
         super(value);
-        this.identifier = identifier;
-        this.typeArgument = genericType;
         this.existingInstances = existingInstances;
-        imports.add(ArrayList.class);
-        imports.add((Class<?>) genericType);
         requiredFacts = value.stream()
                 .map(i -> existingInstances.get(i))
                 .filter(Objects::nonNull)
@@ -51,22 +44,22 @@ class TestGenListValueProvider extends TestGenAbstractValueProvider<List<?>> {
 
     @Override
     public List<Class<?>> getImports() {
-        return imports;
-    }
-
-    @Override
-    public void printSetup(StringBuilder sb) {
-        String e = ((Class<?>) typeArgument).getSimpleName();
-        sb.append(String.format("        ArrayList<%s> %s = new ArrayList<%s>();\n", e, identifier, e));
-        for (Object item : value) {
-            sb.append(String.format("        //%s\n", item));
-            sb.append(String.format("        %s.add(%s);\n", identifier, existingInstances.get(item)));
-        }
+        return Collections.singletonList(Arrays.class);
     }
 
     @Override
     public String toString() {
-        return identifier;
+        StringBuilder sb = new StringBuilder(25 * value.size() + 17);
+        sb.append("Arrays.asList(");
+        Iterator<?> it = value.iterator();
+        if (it.hasNext()) {
+            sb.append(existingInstances.get(it.next()));
+        }
+        while (it.hasNext()) {
+            sb.append(", ").append(existingInstances.get(it.next()));
+        }
+        sb.append(")");
+        return sb.toString();
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenInlineValue.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenInlineValue.java
@@ -15,7 +15,6 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -28,8 +27,7 @@ import java.util.Map;
 public class TestGenInlineValue implements TestGenFact {
 
     private final Object instance;
-    private final String instanceToString;
-    private final ArrayList<Class<?>> imports = new ArrayList<>();
+    private final TestGenValueProvider<?> valueProvider;
 
     public TestGenInlineValue(Object value, Map<Object, TestGenFact> existingInstances) {
         if (value == null) {
@@ -37,11 +35,14 @@ public class TestGenInlineValue implements TestGenFact {
         }
         this.instance = value;
         if (List.class.isAssignableFrom(value.getClass())) {
-            instanceToString = new TestGenListValueProvider((List) value, null, null, existingInstances)
-                    .getInlineValue();
-            imports.add(java.util.Arrays.class);
+            valueProvider = new TestGenInlineListValueProvider((List<?>) value, existingInstances);
         } else {
-            this.instanceToString = value.toString();
+            valueProvider = new TestGenAbstractValueProvider<Object>(value) {
+                @Override
+                public String toString() {
+                    return value.toString();
+                }
+            };
         }
     }
 
@@ -62,12 +63,12 @@ public class TestGenInlineValue implements TestGenFact {
 
     @Override
     public List<TestGenFact> getDependencies() {
-        return Collections.emptyList();
+        return valueProvider.getRequiredFacts();
     }
 
     @Override
     public List<Class<?>> getImports() {
-        return Collections.unmodifiableList(imports);
+        return valueProvider.getImports();
     }
 
     @Override
@@ -87,7 +88,7 @@ public class TestGenInlineValue implements TestGenFact {
 
     @Override
     public String toString() {
-        return instanceToString;
+        return valueProvider.toString();
     }
 
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenInlineValue.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenInlineValue.java
@@ -15,6 +15,7 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,7 @@ public class TestGenInlineValue implements TestGenFact {
 
     private final Object instance;
     private final String instanceToString;
+    private final ArrayList<Class<?>> imports = new ArrayList<>();
 
     public TestGenInlineValue(Object value, Map<Object, TestGenFact> existingInstances) {
         if (value == null) {
@@ -37,6 +39,7 @@ public class TestGenInlineValue implements TestGenFact {
         if (List.class.isAssignableFrom(value.getClass())) {
             instanceToString = new TestGenListValueProvider((List) value, null, null, existingInstances)
                     .getInlineValue();
+            imports.add(java.util.Arrays.class);
         } else {
             this.instanceToString = value.toString();
         }
@@ -64,7 +67,7 @@ public class TestGenInlineValue implements TestGenFact {
 
     @Override
     public List<Class<?>> getImports() {
-        return Collections.emptyList();
+        return Collections.unmodifiableList(imports);
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenInlineValue.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenInlineValue.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.score.director.drools.testgen.fact;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Inline value is a value of a shadow variable. From planning perspective, the value is computed from other variable's
+ * value. From TestGen perspective, the value is not part of the working facts that are recorded during initial
+ * KIE session insertion. It is an anonymous constant created just for the single KIE session update.
+ */
+public class TestGenInlineValue implements TestGenFact {
+
+    private final Object instance;
+    private final String instanceToString;
+
+    public TestGenInlineValue(Object value, Map<Object, TestGenFact> existingInstances) {
+        if (value == null) {
+            throw new IllegalStateException("Value may not be null.");
+        }
+        this.instance = value;
+        if (List.class.isAssignableFrom(value.getClass())) {
+            instanceToString = new TestGenListValueProvider((List) value, null, null, existingInstances)
+                    .getInlineValue();
+        } else {
+            this.instanceToString = value.toString();
+        }
+    }
+
+    @Override
+    public void setUp(Map<Object, TestGenFact> existingInstances) {
+        // no setup needed
+    }
+
+    @Override
+    public Object getInstance() {
+        return instance;
+    }
+
+    @Override
+    public List<TestGenFactField> getFields() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<TestGenFact> getDependencies() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Class<?>> getImports() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void reset() {
+        // no reset needed
+    }
+
+    @Override
+    public void printInitialization(StringBuilder sb) {
+        // no initialization
+    }
+
+    @Override
+    public void printSetup(StringBuilder sb) {
+        // no setup
+    }
+
+    @Override
+    public String toString() {
+        return instanceToString;
+    }
+
+}

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenInlineValue.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenInlineValue.java
@@ -15,6 +15,7 @@
  */
 package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,10 +34,12 @@ public class TestGenInlineValue implements TestGenFact {
         if (value == null) {
             throw new IllegalStateException("Value may not be null.");
         }
-        this.instance = value;
         if (List.class.isAssignableFrom(value.getClass())) {
-            valueProvider = new TestGenInlineListValueProvider((List<?>) value, existingInstances);
+            List<?> copy = new ArrayList<>((List<?>) value);
+            instance = Collections.unmodifiableList(copy);
+            valueProvider = new TestGenInlineListValueProvider(copy, existingInstances);
         } else {
+            instance = value;
             valueProvider = new TestGenAbstractValueProvider<Object>(value) {
                 @Override
                 public String toString() {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenListValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenListValueProvider.java
@@ -17,6 +17,7 @@ package org.optaplanner.core.impl.score.director.drools.testgen.fact;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -62,6 +63,20 @@ class TestGenListValueProvider extends TestGenAbstractValueProvider<List<?>> {
             sb.append(String.format("        //%s\n", item));
             sb.append(String.format("        %s.add(%s);\n", identifier, existingInstances.get(item)));
         }
+    }
+
+    public String getInlineValue() {
+        StringBuilder sb = new StringBuilder(25 * value.size() + 17);
+        sb.append("Arrays.asList(");
+        Iterator<?> it = value.iterator();
+        if (it.hasNext()) {
+            sb.append(existingInstances.get(it.next()));
+        }
+        while (it.hasNext()) {
+            sb.append(", ").append(existingInstances.get(it.next()));
+        }
+        sb.append(")");
+        return sb.toString();
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenListValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenListValueProvider.java
@@ -57,7 +57,7 @@ class TestGenListValueProvider extends TestGenAbstractValueProvider<List<?>> {
     @Override
     public void printSetup(StringBuilder sb) {
         String e = ((Class<?>) typeArgument).getSimpleName();
-        sb.append(String.format("        ArrayList<%s> %s = new ArrayList<%s>();\n", e, identifier, e));
+        sb.append(String.format("        ArrayList<%s> %s = new ArrayList<>();\n", e, identifier));
         for (Object item : value) {
             sb.append(String.format("        //%s\n", item));
             sb.append(String.format("        %s.add(%s);\n", identifier, existingInstances.get(item)));

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenMapValueProvider.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenMapValueProvider.java
@@ -63,10 +63,13 @@ class TestGenMapValueProvider extends TestGenAbstractValueProvider<Map<?, ?>> {
     public void printSetup(StringBuilder sb) {
         String k = ((Class<?>) typeArguments[0]).getSimpleName();
         String v = ((Class<?>) typeArguments[1]).getSimpleName();
-        sb.append(String.format("        HashMap<%s, %s> %s = new HashMap<%s, %s>();\n", k, v, identifier, k, v));
+        sb.append(String.format("        HashMap<%s, %s> %s = new HashMap<>();\n", k, v, identifier));
         for (Map.Entry<? extends Object, ? extends Object> entry : value.entrySet()) {
             sb.append(String.format("        //%s => %s\n", entry.getKey(), entry.getValue()));
-            sb.append(String.format("        %s.put(%s, %s);\n", identifier, existingInstances.get(entry.getKey()), existingInstances.get(entry.getValue())));
+            sb.append(String.format("        %s.put(%s, %s);\n",
+                    identifier,
+                    existingInstances.get(entry.getKey()),
+                    existingInstances.get(entry.getValue())));
         }
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenNullFact.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenNullFact.java
@@ -21,6 +21,11 @@ import java.util.Map;
 
 public class TestGenNullFact implements TestGenFact {
 
+    public static final TestGenNullFact INSTANCE = new TestGenNullFact();
+
+    private TestGenNullFact() {
+    }
+
     @Override
     public void setUp(Map<Object, TestGenFact> existingInstances) {
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFact.java
@@ -66,44 +66,44 @@ public class TestGenValueFact implements TestGenFact {
             Object value = accessor.executeGetter(instance);
             if (value != null) {
                 if (field.getType().equals(String.class)) {
-                    fields.add(new TestGenFactField(this, accessor, new TestGenStringValueProvider((String) value)));
+                    fields.add(new TestGenFactField(this, fieldName, new TestGenStringValueProvider((String) value)));
                 } else if (field.getType().isPrimitive()) {
-                    fields.add(new TestGenFactField(this, accessor, new TestGenPrimitiveValueProvider(value)));
+                    fields.add(new TestGenFactField(this, fieldName, new TestGenPrimitiveValueProvider(value)));
                 } else if (field.getType().isEnum()) {
-                    fields.add(new TestGenFactField(this, accessor, new TestGenEnumValueProvider((Enum) value)));
+                    fields.add(new TestGenFactField(this, fieldName, new TestGenEnumValueProvider((Enum) value)));
                 } else if (existingInstances.containsKey(value)) {
                     String id = existingInstances.get(value).toString();
                     TestGenExistingInstanceValueProvider instanceProvider = new TestGenExistingInstanceValueProvider(
                             value, id, existingInstances.get(value));
-                    fields.add(new TestGenFactField(this, accessor, instanceProvider));
+                    fields.add(new TestGenFactField(this, fieldName, instanceProvider));
                 } else if (field.getType().equals(List.class)) {
                     String id = variableName + "_" + field.getName();
                     Type[] typeArgs = ((ParameterizedType) field.getGenericType()).getActualTypeArguments();
                     TestGenListValueProvider listValueProvider = new TestGenListValueProvider(
                             (List) value, id, typeArgs[0], existingInstances);
-                    fields.add(new TestGenFactField(this, accessor, listValueProvider));
+                    fields.add(new TestGenFactField(this, fieldName, listValueProvider));
                 } else if (field.getType().equals(Set.class)) {
                     String id = variableName + "_" + field.getName();
                     Type[] typeArgs = ((ParameterizedType) field.getGenericType()).getActualTypeArguments();
                     TestGenSetValueProvider setValueProvider = new TestGenSetValueProvider(
                             (Set) value, id, typeArgs[0], existingInstances);
-                    fields.add(new TestGenFactField(this, accessor, setValueProvider));
+                    fields.add(new TestGenFactField(this, fieldName, setValueProvider));
                 } else if (field.getType().equals(Map.class)) {
                     String id = variableName + "_" + field.getName();
                     Type[] typeArgs = ((ParameterizedType) field.getGenericType()).getActualTypeArguments();
                     TestGenMapValueProvider mapValueProvider = new TestGenMapValueProvider(
                             (Map) value, id, typeArgs, existingInstances);
-                    fields.add(new TestGenFactField(this, accessor, mapValueProvider));
+                    fields.add(new TestGenFactField(this, fieldName, mapValueProvider));
                 } else {
                     Method parseMethod = getParseMethod(field);
                     if (parseMethod != null) {
-                        fields.add(new TestGenFactField(this, accessor, new TestGenParsedValueProvider(parseMethod, value)));
+                        fields.add(new TestGenFactField(this, fieldName, new TestGenParsedValueProvider(parseMethod, value)));
                     } else {
                         throw new IllegalStateException("Unsupported type: " + field.getType());
                     }
                 }
             } else {
-                fields.add(new TestGenFactField(this, accessor, new TestGenNullValueProvider()));
+                fields.add(new TestGenFactField(this, fieldName, new TestGenNullValueProvider()));
             }
         }
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionDelete.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionDelete.java
@@ -21,22 +21,22 @@ import org.optaplanner.core.impl.score.director.drools.testgen.fact.TestGenFact;
 public class TestGenKieSessionDelete implements TestGenKieSessionOperation {
 
     private final int id;
-    private final TestGenFact entity;
+    private final TestGenFact fact;
 
-    public TestGenKieSessionDelete(int id, TestGenFact entity) {
+    public TestGenKieSessionDelete(int id, TestGenFact fact) {
         this.id = id;
-        this.entity = entity;
+        this.fact = fact;
     }
 
     @Override
     public void invoke(KieSession kieSession) {
-        kieSession.delete(kieSession.getFactHandle(entity.getInstance()));
+        kieSession.delete(kieSession.getFactHandle(fact.getInstance()));
     }
 
     @Override
     public void print(StringBuilder sb) {
         sb.append(String.format("        //%s\n", this));
-        sb.append(String.format("        kieSession.delete(kieSession.getFactHandle(%s));\n", entity));
+        sb.append(String.format("        kieSession.delete(kieSession.getFactHandle(%s));\n", fact));
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionFireAllRules.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionFireAllRules.java
@@ -43,7 +43,7 @@ public class TestGenKieSessionFireAllRules implements TestGenKieSessionOperation
 
     @Override
     public void invoke(KieSession kieSession) {
-        logger.trace("        FIRE");
+        logger.trace("        [{}] FIRE ALL RULES", id);
         kieSession.fireAllRules();
     }
 

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionFireAllRules.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionFireAllRules.java
@@ -22,10 +22,23 @@ import org.slf4j.LoggerFactory;
 public class TestGenKieSessionFireAllRules implements TestGenKieSessionOperation {
 
     private static final Logger logger = LoggerFactory.getLogger(TestGenKieSessionFireAllRules.class);
+    private static int fireCounter = 0;
+    private final int fireId;
     private final int id;
+    private final boolean assertFire;
 
-    public TestGenKieSessionFireAllRules(int id) {
+    public TestGenKieSessionFireAllRules(int id, boolean assertFire) {
+        fireId = fireCounter++;
         this.id = id;
+        this.assertFire = assertFire;
+    }
+
+    public boolean isAssertFire() {
+        return assertFire;
+    }
+
+    public int getFireId() {
+        return fireId;
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionInsert.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionInsert.java
@@ -24,6 +24,9 @@ public class TestGenKieSessionInsert implements TestGenKieSessionOperation {
     private final TestGenFact fact;
 
     public TestGenKieSessionInsert(int id, TestGenFact fact) {
+        if (fact == null) {
+            throw new IllegalArgumentException("Fact may not be null.");
+        }
         this.id = id;
         this.fact = fact;
     }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionUpdate.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/operation/TestGenKieSessionUpdate.java
@@ -36,7 +36,8 @@ public class TestGenKieSessionUpdate implements TestGenKieSessionOperation {
     private final String setterName;
     private final TestGenFact value;
 
-    public TestGenKieSessionUpdate(int id, TestGenFact entity, VariableDescriptor<?> variableDescriptor, TestGenFact value) {
+    public TestGenKieSessionUpdate(int id, TestGenFact entity, VariableDescriptor<?> variableDescriptor,
+            TestGenFact value) {
         if (value == null) {
             throw new IllegalArgumentException("value may not be null");
         }
@@ -63,7 +64,14 @@ public class TestGenKieSessionUpdate implements TestGenKieSessionOperation {
 
     @Override
     public void invoke(KieSession kieSession) {
-        logger.trace("        {} ← {}", entity.getInstance(), value.getInstance());
+        if (logger.isTraceEnabled()) {
+            logger.trace("        [{}] {}.{}: {} → {}",
+                    id,
+                    entity.getInstance(),
+                    accessor.getName(),
+                    accessor.executeGetter(entity.getInstance()),
+                    value.getInstance());
+        }
         accessor.executeSetter(entity.getInstance(), value.getInstance());
         FactHandle fh = kieSession.getFactHandle(entity.getInstance());
         if (fh == null) {

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedScoreReproducer.java
@@ -28,6 +28,10 @@ import org.optaplanner.core.impl.score.director.drools.testgen.operation.TestGen
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Detects corrupted score for the given journal. It should behave equally to
+ * {@link AbstractScoreDirector#assertWorkingScoreFromScratch(Score, Object)}.
+ */
 public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemReproducer, TestGenKieSessionListener {
 
     private static final Logger logger = LoggerFactory.getLogger(TestGenCorruptedScoreReproducer.class);
@@ -45,18 +49,12 @@ public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemRe
     }
 
     @Override
-    public void assertReproducible(TestGenKieSessionJournal journal, String message) {
+    public void assertReproducible(TestGenKieSessionJournal journal, String contextDescription) {
         if (!isReproducible(journal)) {
-            throw new IllegalStateException(message + " The score is not corrupted.");
+            throw new IllegalStateException(contextDescription + " The score is not corrupted.");
         }
     }
 
-    /**
-     * Detects corrupted score for the given journal. It should behave equally to
-     * {@link AbstractScoreDirector#assertWorkingScoreFromScratch(Score, Object)}.
-     * @param journal journal tested for corrupted score
-     * @return true if replaying the journal leads to the original corrupted score
-     */
     @Override
     public boolean isReproducible(TestGenKieSessionJournal journal) {
         journal.addListener(this);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedVariableListenerReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedVariableListenerReproducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,17 +24,20 @@ import org.optaplanner.core.impl.score.director.drools.testgen.TestGenDroolsScor
 import org.optaplanner.core.impl.score.director.drools.testgen.TestGenKieSessionJournal;
 import org.optaplanner.core.impl.score.director.drools.testgen.TestGenKieSessionListener;
 import org.optaplanner.core.impl.score.director.drools.testgen.operation.TestGenKieSessionFireAllRules;
-import org.optaplanner.core.impl.score.director.drools.testgen.operation.TestGenKieSessionInsert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemReproducer, TestGenKieSessionListener {
+public class TestGenCorruptedVariableListenerReproducer implements
+        TestGenOriginalProblemReproducer,
+        TestGenKieSessionListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestGenCorruptedScoreReproducer.class);
+    private static final Logger logger = LoggerFactory.getLogger(TestGenCorruptedVariableListenerReproducer.class);
     private final String analysis;
     private final TestGenDroolsScoreDirector<?> scoreDirector;
+    private Score<?> lastWorkingScore;
+    private int lastFireId;
 
-    public TestGenCorruptedScoreReproducer(String analysis, TestGenDroolsScoreDirector<?> scoreDirector) {
+    public TestGenCorruptedVariableListenerReproducer(String analysis, TestGenDroolsScoreDirector<?> scoreDirector) {
         this.analysis = analysis;
         this.scoreDirector = scoreDirector;
     }
@@ -47,18 +50,20 @@ public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemRe
     @Override
     public void assertReproducible(TestGenKieSessionJournal journal, String message) {
         if (!isReproducible(journal)) {
-            throw new IllegalStateException(message + " The score is not corrupted.");
+            throw new IllegalStateException(message + " Variable listeners are not corrupted.");
         }
     }
 
     /**
-     * Detects corrupted score for the given journal. It should behave equally to
-     * {@link AbstractScoreDirector#assertWorkingScoreFromScratch(Score, Object)}.
-     * @param journal journal tested for corrupted score
-     * @return true if replaying the journal leads to the original corrupted score
+     * Detects variable listener corruption. This condition is indicated by a difference between last working score and
+     * the score calculated during {@link AbstractScoreDirector#assertShadowVariablesAreNotStale()}.
+     * @param journal journal tested for a corrupted variable listener
+     * @return true if replaying the journal leads to the original corrupted score (after triggering variable listeners)
      */
     @Override
     public boolean isReproducible(TestGenKieSessionJournal journal) {
+        lastWorkingScore = null;
+        lastFireId = Integer.MAX_VALUE;
         journal.addListener(this);
         try {
             journal.replay(scoreDirector.createKieSession());
@@ -82,19 +87,21 @@ public class TestGenCorruptedScoreReproducer implements TestGenOriginalProblemRe
     @Override
     public void afterFireAllRules(KieSession kieSession, TestGenKieSessionJournal journal,
             TestGenKieSessionFireAllRules fire) {
-        KieSession uncorruptedSession = scoreDirector.createKieSession();
-        for (TestGenKieSessionInsert insert : journal.getInitialInserts()) {
-            Object object = insert.getFact().getInstance();
-            uncorruptedSession.insert(object);
-        }
-        uncorruptedSession.fireAllRules();
-        uncorruptedSession.dispose();
-        Score<?> uncorruptedScore = extractScore(uncorruptedSession);
         Score<?> workingScore = extractScore(kieSession);
-        if (!workingScore.equals(uncorruptedScore)) {
-            logger.debug("    Score: working[{}], uncorrupted[{}]", workingScore, uncorruptedScore);
-            throw new TestGenCorruptedScoreException(workingScore, uncorruptedScore);
+        if (fire.isAssertFire()) {
+            logger.debug("    [Assert mode] Score: working[{}], uncorrupted[{}] ({})",
+                    workingScore, lastWorkingScore, fire);
+            // if this assertion fire's score is different from the previous fire it means that a shadow variable
+            // update was corrupted
+            if (lastFireId == fire.getFireId() - 1
+                    && !workingScore.equals(lastWorkingScore)) {
+                throw new TestGenCorruptedScoreException(workingScore, lastWorkingScore);
+            }
+        } else {
+            logger.debug("      Score: {} ({})", workingScore, fire);
         }
+        lastWorkingScore = workingScore;
+        lastFireId = fire.getFireId();
     }
 
     @Override

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedVariableListenerReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedVariableListenerReproducer.java
@@ -27,6 +27,10 @@ import org.optaplanner.core.impl.score.director.drools.testgen.operation.TestGen
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Detects variable listener corruption. This condition is indicated by a difference between last working score and
+ * the score calculated during {@link AbstractScoreDirector#assertShadowVariablesAreNotStale(Score, Object)}.
+ */
 public class TestGenCorruptedVariableListenerReproducer implements
         TestGenOriginalProblemReproducer,
         TestGenKieSessionListener {
@@ -48,18 +52,12 @@ public class TestGenCorruptedVariableListenerReproducer implements
     }
 
     @Override
-    public void assertReproducible(TestGenKieSessionJournal journal, String message) {
+    public void assertReproducible(TestGenKieSessionJournal journal, String contextDescription) {
         if (!isReproducible(journal)) {
-            throw new IllegalStateException(message + " Variable listeners are not corrupted.");
+            throw new IllegalStateException(contextDescription + " Variable listeners are not corrupted.");
         }
     }
 
-    /**
-     * Detects variable listener corruption. This condition is indicated by a difference between last working score and
-     * the score calculated during {@link AbstractScoreDirector#assertShadowVariablesAreNotStale()}.
-     * @param journal journal tested for a corrupted variable listener
-     * @return true if replaying the journal leads to the original corrupted score (after triggering variable listeners)
-     */
     @Override
     public boolean isReproducible(TestGenKieSessionJournal journal) {
         lastWorkingScore = null;

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedVariableListenerReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenCorruptedVariableListenerReproducer.java
@@ -16,6 +16,7 @@
 package org.optaplanner.core.impl.score.director.drools.testgen.reproducer;
 
 import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.rule.ConsequenceException;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.holder.ScoreHolder;
 import org.optaplanner.core.impl.score.director.AbstractScoreDirector;
@@ -68,6 +69,9 @@ public class TestGenCorruptedVariableListenerReproducer implements
             return false;
         } catch (TestGenCorruptedScoreException e) {
             return true;
+        } catch (ConsequenceException e) {
+            logger.debug("    Journal pruning not possible: {}", e.toString());
+            return false;
         } catch (RuntimeException e) {
             if (e.getMessage() != null && e.getMessage().startsWith("No fact handle for ")) {
                 // this is common when removing insert of a fact that is later updated - not interesting

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenDroolsExceptionReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenDroolsExceptionReproducer.java
@@ -22,13 +22,17 @@ import org.optaplanner.core.impl.score.director.drools.testgen.TestGenKieSession
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Reproduces the exception originally thrown by Drools during a call to KIE session.
+ */
 public class TestGenDroolsExceptionReproducer implements TestGenOriginalProblemReproducer {
 
     private static final Logger logger = LoggerFactory.getLogger(TestGenDroolsExceptionReproducer.class);
     private final RuntimeException originalException;
     private final TestGenDroolsScoreDirector<?> scoreDirector;
 
-    public TestGenDroolsExceptionReproducer(RuntimeException originalException, TestGenDroolsScoreDirector<?> scoreDirector) {
+    public TestGenDroolsExceptionReproducer(RuntimeException originalException,
+            TestGenDroolsScoreDirector<?> scoreDirector) {
         this.originalException = originalException;
         this.scoreDirector = scoreDirector;
     }
@@ -59,13 +63,13 @@ public class TestGenDroolsExceptionReproducer implements TestGenOriginalProblemR
     }
 
     @Override
-    public void assertReproducible(TestGenKieSessionJournal journal, String message) {
+    public void assertReproducible(TestGenKieSessionJournal journal, String contextDescription) {
         try {
             journal.replay(scoreDirector.createKieSession());
-            throw new IllegalStateException(message + " No exception thrown.");
+            throw new IllegalStateException(contextDescription + " No exception thrown.");
         } catch (RuntimeException reproducedException) {
             if (!areEqual(originalException, reproducedException)) {
-                throw new IllegalStateException(message
+                throw new IllegalStateException(contextDescription
                         + "\nExpected [" + originalException + "]"
                         + "\nCaused [" + reproducedException + "]",
                         reproducedException);

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenOriginalProblemReproducer.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/score/director/drools/testgen/reproducer/TestGenOriginalProblemReproducer.java
@@ -19,7 +19,18 @@ import org.optaplanner.core.impl.score.director.drools.testgen.TestGenKieSession
 
 public interface TestGenOriginalProblemReproducer {
 
+    /**
+     * Replay the journal and decide if the original problem is reproducible.
+     * @param journal journal tested for the original problem
+     * @return true if replaying the journal leads to the original problem
+     */
     boolean isReproducible(TestGenKieSessionJournal journal);
 
-    void assertReproducible(TestGenKieSessionJournal journal, String message);
+    /**
+     * Throws exception if the original problem is not reproducible with the given journal.
+     * @param journal journal tested for the original problem
+     * @param contextDescription describes the context in which the problem should be reproducible
+     */
+    void assertReproducible(TestGenKieSessionJournal journal, String contextDescription);
+
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.optaplanner.core.impl.testdata.domain.TestdataEntity;
 import org.optaplanner.core.impl.testdata.domain.TestdataValue;
 import org.optaplanner.core.impl.testdata.domain.collection.TestdataEntityCollectionPropertyEntity;
+import org.optaplanner.core.impl.testdata.domain.testgen.TestdataGetterSetterTypeMismatch;
 
 import static org.junit.Assert.*;
 
@@ -134,4 +135,22 @@ public class TestGenValueFactTest {
         assertTrue(imports.contains(HashMap.class));
         assertTrue(imports.contains(String.class));
     }
+
+    /**
+     * Covers situations where getter returns a supertype of the property type. This occurs in the Coach Shuttle
+     * Gathering example.
+     */
+    @Test
+    public void getterSetterTypeMismatch() {
+        TestdataGetterSetterTypeMismatch instance = new TestdataGetterSetterTypeMismatch();
+        instance.setDescription("desc");
+        TestGenValueFact fact = new TestGenValueFact(0, instance);
+        HashMap<Object, TestGenFact> instances = new HashMap<>();
+        fact.setUp(instances);
+        instance.setDescription("");
+        assertEquals("", instance.getDescription());
+        fact.reset();
+        assertEquals("desc", instance.getDescription());
+    }
+
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/fact/TestGenValueFactTest.java
@@ -153,4 +153,26 @@ public class TestGenValueFactTest {
         assertEquals("desc", instance.getDescription());
     }
 
+    @Test
+    public void inlineValueList() {
+        // prepare instances and facts
+        TestdataEntity a = new TestdataEntity();
+        TestdataEntity b = new TestdataEntity();
+        TestGenValueFact fa = new TestGenValueFact(0, a);
+        TestGenValueFact fb = new TestGenValueFact(1, b);
+        HashMap<Object, TestGenFact> instances = new HashMap<>();
+        instances.put(a, fa);
+        instances.put(b, fb);
+
+        // create the "inverse list" (simulation of inverse relationship shadow variable)
+        ArrayList<TestdataEntity> inverseList = new ArrayList<>();
+        inverseList.add(a);
+        inverseList.add(b);
+
+        // create the inline value of the inverse list
+        TestGenInlineValue val = new TestGenInlineValue(inverseList, instances);
+        assertTrue(val.getImports().contains(Arrays.class));
+        assertEquals("Arrays.asList(" + fa.getVariableName() + ", " + fb.getVariableName() + ")", val.toString());
+    }
+
 }

--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/testgen/TestdataGetterSetterTypeMismatch.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/testdata/domain/testgen/TestdataGetterSetterTypeMismatch.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.optaplanner.core.impl.testdata.domain.testgen;
+
+public class TestdataGetterSetterTypeMismatch {
+
+    private String description;
+
+    public CharSequence getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/location/RoadLocationArc.java
+++ b/optaplanner-examples/src/main/java/org/optaplanner/examples/coachshuttlegathering/domain/location/RoadLocationArc.java
@@ -67,4 +67,12 @@ public class RoadLocationArc implements Serializable {
     // Complex methods
     // ************************************************************************
 
+    @Override
+    public String toString() {
+        return "Road arc [coach: "
+                + coachDistance + "m/" + coachDuration
+                + "s, shuttle: "
+                + shuttleDistance + "m/" + shuttleDuration + "s]";
+    }
+
 }


### PR DESCRIPTION
CSG uses shadow variables (custom and inverse relationship), which lead to updates with values that are not working facts (e.g. transportTimeToHub is an Integer, transferShuttleList is an ArrayList). TestGen now handles these dynamic non-fact values using the `TestGenInlineValue`.

Another anomaly to cope with was the `Coach.destination` property whose type is `BusHub` but the getter is a supertype (`StopOrHub`).

A new "reproducer" (reproducibility decider) for corrupted variable listeners was added. It is not fully compatible with the current pruning strategy but it works when only dropping the oldest updates. FIXME comment included.

TestGen score director's logging was enhanced so that each Move updates are now visible in full detail:
```
// do move
Updating variable H1.transferShuttleList[List]: [S1, S2, S3, S4, S5, S6] → [S1, S2, S3, S4, S5]
Updating variable S6.destination[StopOrHub]: H1 → B2
Updating variable B2.transferShuttleList[List]: [] → [S6]
// undo move
Updating variable B2.transferShuttleList[List]: [S6] → []
Updating variable S6.destination[StopOrHub]: B2 → H1
Updating variable H1.transferShuttleList[List]: [S1, S2, S3, S4, S5] → [S1, S2, S3, S4, S5, S6]
Move index (2), score (0hard/-412040soft), accepted (true), move (S6 {H1 -> B2}).
```