### PR TITLE
Remove build status link from Readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,3 @@
-image:https://jenkins-kieci.rhcloud.com/buildStatus/icon?job=optaplanner["Build Status", link="https://jenkins-kieci.rhcloud.com/job/optaplanner"]
-
 == Quick development start
 
 To build and run from source:


### PR DESCRIPTION
The public CI server is unavailable and won't be available in the near future.
@psiroky told me the idea of a public CI server was suspended due to maintenance related issues.