### PR TITLE
[7.x] PLANNER-1868 SolverManager needs an API that allows a user to listen o both best solution and solver terminated events

### DIFF
--- a/optaplanner-core/src/build/revapi-config.json
+++ b/optaplanner-core/src/build/revapi-config.json
@@ -26,7 +26,17 @@
   "ignores": {
     "revapi": {
       "_comment": "Changes between 7.39.0.Final and the current branch. These changes are desired and thus ignored.",
-      "ignore": []
+      "ignore": [
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.optaplanner.core.api.solver.SolverJob<Solution_, ProblemId_> org.optaplanner.core.api.solver.SolverManager<Solution_, ProblemId_>::solveAndListen(ProblemId_, java.util.function.Function<? super ProblemId_, ? extends Solution_>, java.util.function.Consumer<? super Solution_>, java.util.function.Consumer<? super Solution_>, java.util.function.BiConsumer<? super ProblemId_, ? super java.lang.Throwable>)",
+          "package": "org.optaplanner.core.api.solver",
+          "classSimpleName": "SolverManager",
+          "methodName": "solveAndListen",
+          "elementKind": "method",
+          "justification": "SolverManager needs an API that allows a user to listen to both best solution and solver terminated events"
+        }
+      ]
     }
   }
 }

--- a/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/SolverManager.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/api/solver/SolverManager.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.score.ScoreManager;
 import org.optaplanner.core.api.solver.event.BestSolutionChangedEvent;
 import org.optaplanner.core.config.solver.SolverConfig;
@@ -207,7 +208,7 @@ public interface SolverManager<Solution_, ProblemId_> extends AutoCloseable {
      */
     default SolverJob<Solution_, ProblemId_> solveAndListen(ProblemId_ problemId,
             Function<? super ProblemId_, ? extends Solution_> problemFinder, Consumer<? super Solution_> bestSolutionConsumer) {
-        return solveAndListen(problemId, problemFinder, bestSolutionConsumer, null);
+        return solveAndListen(problemId, problemFinder, bestSolutionConsumer, null, null);
     }
 
     /**
@@ -223,8 +224,39 @@ public interface SolverManager<Solution_, ProblemId_> extends AutoCloseable {
      *        If null it defaults to logging the exception as an error.
      * @return never null
      */
+    default SolverJob<Solution_, ProblemId_> solveAndListen(ProblemId_ problemId,
+            Function<? super ProblemId_, ? extends Solution_> problemFinder,
+            Consumer<? super Solution_> bestSolutionConsumer,
+            BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler) {
+        return solveAndListen(problemId, problemFinder, bestSolutionConsumer, null, exceptionHandler);
+    }
+
+    /**
+     * As defined by {@link #solveAndListen(Object, Function, Consumer)}.
+     * <p>
+     * The final best solution is delivered twice:
+     * first to the {@code bestSolutionConsumer} when it is found
+     * and then again to the {@code finalBestSolutionConsumer} when the solver terminates.
+     * Do not store the solution twice.
+     * This allows for use cases that only process the {@link Score} first (during best solution changed events)
+     * and then store the solution upon termination.
+     *
+     * @param problemId never null, an ID for each planning problem. This must be unique.
+     *        Use this problemId to {@link #terminateEarly(Object) terminate} the solver early,
+     *        {@link #getSolverStatus(Object) to get the status} or if the problem changes while solving.
+     * @param problemFinder never null, function that returns a {@link PlanningSolution}, usually with uninitialized planning
+     *        variables
+     * @param bestSolutionConsumer never null, called multiple times, on a consumer thread
+     * @param finalBestSolutionConsumer sometimes null, called only once, at the end, on a consumer thread.
+     *        That final best solution is already consumed by the bestSolutionConsumer earlier.
+     * @param exceptionHandler sometimes null, called if an exception or error occurs.
+     *        If null it defaults to logging the exception as an error.
+     * @return never null
+     */
     SolverJob<Solution_, ProblemId_> solveAndListen(ProblemId_ problemId,
-            Function<? super ProblemId_, ? extends Solution_> problemFinder, Consumer<? super Solution_> bestSolutionConsumer,
+            Function<? super ProblemId_, ? extends Solution_> problemFinder,
+            Consumer<? super Solution_> bestSolutionConsumer,
+            Consumer<? super Solution_> finalBestSolutionConsumer,
             BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler);
 
     /**

--- a/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverManager.java
+++ b/optaplanner-core/src/main/java/org/optaplanner/core/impl/solver/DefaultSolverManager.java
@@ -86,8 +86,9 @@ public final class DefaultSolverManager<Solution_, ProblemId_> implements Solver
     public SolverJob<Solution_, ProblemId_> solveAndListen(ProblemId_ problemId,
             Function<? super ProblemId_, ? extends Solution_> problemFinder,
             Consumer<? super Solution_> bestSolutionConsumer,
+            Consumer<? super Solution_> finalBestSolutionConsumer,
             BiConsumer<? super ProblemId_, ? super Throwable> exceptionHandler) {
-        return solve(problemId, problemFinder, bestSolutionConsumer, null, exceptionHandler);
+        return solve(problemId, problemFinder, bestSolutionConsumer, finalBestSolutionConsumer, exceptionHandler);
     }
 
     protected SolverJob<Solution_, ProblemId_> solve(ProblemId_ problemId,


### PR DESCRIPTION
This is the backport. It's a pure cherry pick except for the revapi changes.