### PR TITLE
Clean up config excerpts in docs

### DIFF
--- a/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/BenchmarkingAndTweaking/BenchmarkingAndTweaking-chapter.adoc
@@ -100,14 +100,14 @@ A benchmark configuration XML file looks like this:
   <benchmarkDirectory>local/data/nqueens</benchmarkDirectory>
 
   <inheritedSolverBenchmark>
+    <solver>
+      ...<!-- Common solver configuration -->
+    </solver>
     <problemBenchmarks>
       ...
       <inputSolutionFile>data/cloudbalancing/unsolved/100computers-300processes.xml</inputSolutionFile>
       <inputSolutionFile>data/cloudbalancing/unsolved/200computers-600processes.xml</inputSolutionFile>
     </problemBenchmarks>
-    <solver>
-      ...<!-- Common solver configuration -->
-    </solver>
   </inheritedSolverBenchmark>
 
   <solverBenchmark>
@@ -373,11 +373,6 @@ To quickly configure and run a benchmark for typical solver configs, use a `solv
   <benchmarkDirectory>local/data/nqueens</benchmarkDirectory>
 
   <inheritedSolverBenchmark>
-    <problemBenchmarks>
-      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensXmlSolutionFileIO</solutionFileIOClass>
-      <inputSolutionFile>data/nqueens/unsolved/32queens.xml</inputSolutionFile>
-      <inputSolutionFile>data/nqueens/unsolved/64queens.xml</inputSolutionFile>
-    </problemBenchmarks>
     <solver>
       <solutionClass>org.optaplanner.examples.nqueens.domain.NQueens</solutionClass>
       <entityClass>org.optaplanner.examples.nqueens.domain.Queen</entityClass>
@@ -389,6 +384,11 @@ To quickly configure and run a benchmark for typical solver configs, use a `solv
         <minutesSpentLimit>1</minutesSpentLimit>
       </termination>
     </solver>
+    <problemBenchmarks>
+      <solutionFileIOClass>org.optaplanner.examples.nqueens.persistence.NQueensXmlSolutionFileIO</solutionFileIOClass>
+      <inputSolutionFile>data/nqueens/unsolved/32queens.xml</inputSolutionFile>
+      <inputSolutionFile>data/nqueens/unsolved/64queens.xml</inputSolutionFile>
+    </problemBenchmarks>
   </inheritedSolverBenchmark>
 
   <solverBenchmarkBluePrint>

--- a/optaplanner-docs/src/main/asciidoc/ConstraintStreams/ConstraintStreams-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/ConstraintStreams/ConstraintStreams-chapter.adoc
@@ -998,9 +998,9 @@ To try it out set the `constraintStreamImplType` to `BAVET` in your solver confi
     <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
       <scoreDirectorFactory>
+        <constraintProviderClass>com.example.MyConstraintProvider</constraintProviderClass>
         <!-- BAVET is experimental -->
         <constraintStreamImplType>BAVET</constraintStreamImplType>
-        <constraintProviderClass>com.example.MyConstraintProvider</constraintProviderClass>
       </scoreDirectorFactory>
       ...
     </solver>

--- a/optaplanner-docs/src/main/asciidoc/ConstructionHeuristics/ConstructionHeuristics-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/ConstructionHeuristics/ConstructionHeuristics-chapter.adoc
@@ -407,8 +407,8 @@ The easiest way to deal with multiple entity classes is to run a separate Constr
   <constructionHeuristic>
     <queuedEntityPlacer>
       <entitySelector id="placerEntitySelector">
-        <cacheType>PHASE</cacheType>
         <entityClass>...DogEntity</entityClass>
+        <cacheType>PHASE</cacheType>
       </entitySelector>
       <changeMoveSelector>
         <entitySelector mimicSelectorRef="placerEntitySelector"/>
@@ -419,8 +419,8 @@ The easiest way to deal with multiple entity classes is to run a separate Constr
   <constructionHeuristic>
     <queuedEntityPlacer>
       <entitySelector id="placerEntitySelector">
-        <cacheType>PHASE</cacheType>
         <entityClass>...CatEntity</entityClass>
+        <cacheType>PHASE</cacheType>
       </entitySelector>
       <changeMoveSelector>
         <entitySelector mimicSelectorRef="placerEntitySelector"/>

--- a/optaplanner-docs/src/main/asciidoc/DroolsScoreCalculation/DroolsScoreCalculation-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/DroolsScoreCalculation/DroolsScoreCalculation-chapter.adoc
@@ -70,7 +70,7 @@ Optionally, you can also set drools configuration properties:
   <scoreDirectorFactory>
     <scoreDrl>org/optaplanner/examples/nqueens/solver/nQueensConstraints.drl</scoreDrl>
     <kieBaseConfigurationProperties>
-      <drools.equalityBehavior>...</drools.equalityBehavior>
+      <property name="drools.equalityBehavior" value="..." />
     </kieBaseConfigurationProperties>
   </scoreDirectorFactory>
 ----

--- a/optaplanner-docs/src/main/asciidoc/LocalSearch/LocalSearch-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/LocalSearch/LocalSearch-chapter.adoc
@@ -463,8 +463,8 @@ Use a lower tabu size than in a pure Tabu Search configuration.
   <localSearch>
     ...
     <acceptor>
-      <simulatedAnnealingStartingTemperature>2hard/100soft</simulatedAnnealingStartingTemperature>
       <entityTabuSize>5</entityTabuSize>
+      <simulatedAnnealingStartingTemperature>2hard/100soft</simulatedAnnealingStartingTemperature>
     </acceptor>
     <forager>
       <acceptedCountLimit>1</acceptedCountLimit>
@@ -528,8 +528,8 @@ Use a lower tabu size than in a pure Tabu Search configuration.
   <localSearch>
     ...
     <acceptor>
-      <lateAcceptanceSize>400</lateAcceptanceSize>
       <entityTabuSize>5</entityTabuSize>
+      <lateAcceptanceSize>400</lateAcceptanceSize>
     </acceptor>
     <forager>
       <acceptedCountLimit>1</acceptedCountLimit>

--- a/optaplanner-docs/src/main/asciidoc/MoveAndNeighborhoodSelection/MoveAndNeighborhoodSelection-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/MoveAndNeighborhoodSelection/MoveAndNeighborhoodSelection-chapter.adoc
@@ -566,7 +566,6 @@ Advanced configuration:
 ----
     <unionMoveSelector>
       ... <!-- Normal selector properties -->
-      <selectorProbabilityWeightFactoryClass>...ProbabilityWeightFactory</selectorProbabilityWeightFactoryClass>
       <changeMoveSelector>
         <fixedProbabilityWeight>...</fixedProbabilityWeight>
         ...
@@ -580,6 +579,7 @@ Advanced configuration:
         ...
       </...MoveSelector>
       ...
+      <selectorProbabilityWeightFactoryClass>...ProbabilityWeightFactory</selectorProbabilityWeightFactoryClass>
     </unionMoveSelector>
 ----
 
@@ -611,9 +611,9 @@ To give each individual `Move` the same selection chance (as opposed to each ``M
 [source,xml,options="nowrap"]
 ----
     <unionMoveSelector>
-      <selectorProbabilityWeightFactoryClass>org.optaplanner.core.impl.heuristic.selector.common.decorator.FairSelectorProbabilityWeightFactory</selectorProbabilityWeightFactoryClass>
       <changeMoveSelector/>
       <swapMoveSelector/>
+      <selectorProbabilityWeightFactoryClass>org.optaplanner.core.impl.heuristic.selector.common.decorator.FairSelectorProbabilityWeightFactory</selectorProbabilityWeightFactoryClass>
     </unionMoveSelector>
 ----
 
@@ -642,7 +642,6 @@ Advanced configuration:
 ----
     <cartesianProductMoveSelector>
       ... <!-- Normal selector properties -->
-      <ignoreEmptyChildIterators>true</ignoreEmptyChildIterators>
       <changeMoveSelector>
         ...
       </changeMoveSelector>
@@ -653,6 +652,7 @@ Advanced configuration:
         ...
       </...MoveSelector>
       ...
+      <ignoreEmptyChildIterators>true</ignoreEmptyChildIterators>
     </cartesianProductMoveSelector>
 ----
 

--- a/optaplanner-docs/src/main/asciidoc/OptimizationAlgorithms/OptimizationAlgorithms-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/OptimizationAlgorithms/OptimizationAlgorithms-chapter.adoc
@@ -622,8 +622,8 @@ Terminations can be combined, for example: terminate after `100` steps or if a s
 ----
   <termination>
     <terminationCompositionStyle>OR</terminationCompositionStyle>
-    <stepCountLimit>100</stepCountLimit>
     <bestScoreLimit>0</bestScoreLimit>
+    <stepCountLimit>100</stepCountLimit>
   </termination>
 ----
 
@@ -633,8 +633,8 @@ Alternatively you can use `AND`, for example: terminate after reaching a feasibl
 ----
   <termination>
     <terminationCompositionStyle>AND</terminationCompositionStyle>
-    <unimprovedStepCountLimit>5</unimprovedStepCountLimit>
     <bestScoreLimit>-100</bestScoreLimit>
+    <unimprovedStepCountLimit>5</unimprovedStepCountLimit>
   </termination>
 ----
 

--- a/optaplanner-docs/src/main/asciidoc/PlannerConfiguration/PlannerConfiguration-chapter.adoc
+++ b/optaplanner-docs/src/main/asciidoc/PlannerConfiguration/PlannerConfiguration-chapter.adoc
@@ -569,18 +569,18 @@ One way to deal with this is to filter the entity selector of the placer in the 
 <solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
   ...
-  <constructionHeuristics>
+  <constructionHeuristic>
     <queuedEntityPlacer>
       <entitySelector id="entitySelector1">
         <filterClass>...</filterClass>
       </entitySelector>
     </queuedEntityPlacer>
     ...
-    <changeMoveselector>
-      <entitySelector mimicRef="entitySelector1" />
-    </changeMoveselector>
+    <changeMoveSelector>
+      <entitySelector mimicSelectorRef="entitySelector1" />
+    </changeMoveSelector>
     ...
-  </constructionHeuristics>
+  </constructionHeuristic>
  ...
 </solver>
 ----


### PR DESCRIPTION
A result of validating every single config XML excerpt in our docs.

There are two more discrepancies between the docs and the reality that are out of the scope of this PR:
https://issues.redhat.com/browse/PLANNER-2516
https://issues.redhat.com/browse/PLANNER-2517

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> please add comment: <b>Jenkins run fdb</b>
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
