### PR TITLE
Bring SonarCloud rating back to green

### DIFF
--- a/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenTestWriterTest.java
+++ b/optaplanner-core/src/test/java/org/optaplanner/core/impl/score/director/drools/testgen/TestGenTestWriterTest.java
@@ -68,7 +68,7 @@ public class TestGenTestWriterTest {
         TestGenTestWriter writer = new TestGenTestWriter();
         writer.setClassName("TestGenWriterOutput");
         writer.setScoreDefinition(new SimpleScoreDefinition());
-        writer.setScoreDrlFileList(Arrays.asList(new File(DRL_FILE_PATH)));
+        writer.setScoreDrlFileList(List.of(new File(DRL_FILE_PATH)));
         writer.setScoreDrlList(Arrays.asList("x", "y"));
         writer.setConstraintMatchEnabled(true);
         writer.setCorruptedScoreException(new TestGenCorruptedScoreException(
@@ -101,7 +101,7 @@ public class TestGenTestWriterTest {
         TestClassWithDateField entity = new TestClassWithDateField();
         Date now = new Date();
         entity.setDate(now);
-        journal.addFacts(Arrays.asList(entity));
+        journal.addFacts(List.of(entity));
 
         TestGenTestWriter writer = new TestGenTestWriter();
         writer.setClassName("TestGenWriterOutput");
@@ -123,14 +123,16 @@ public class TestGenTestWriterTest {
         for (int i = 0; i < Math.min(expectedLines.size(), actualLines.size()); i++) {
             String expectedLine = StringUtils.replace(expectedLines.get(i),
                     DRL_FILE_PLACEHOLDER, new File(DRL_FILE_PATH).getAbsolutePath());
-            assertThat(actualLines.get(i)).isEqualTo(expectedLine).withFailMessage("At line " + (i + 1));
+            assertThat(actualLines.get(i))
+                    .withFailMessage("At line " + (i + 1))
+                    .isEqualTo(expectedLine);
         }
 
         // then check line counts are the same
         assertThat(actualLines).hasSameSizeAs(expectedLines);
 
         // finally check the whole string
-        String expectedString = StringUtils.replace(new String(Files.readAllBytes(expected), StandardCharsets.UTF_8),
+        String expectedString = StringUtils.replace(Files.readString(expected, StandardCharsets.UTF_8),
                 DRL_FILE_PLACEHOLDER, new File(DRL_FILE_PATH).getAbsolutePath());
         assertThat(actual).isEqualTo(expectedString);
     }


### PR DESCRIPTION
Signed-off-by: Lukáš Petrovický <lukas@petrovicky.net>

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple kiegroup repositories and depend on each other. -->
<!-- Example:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
* https://github.com/kiegroup/drools/pull/3000
* https://github.com/kiegroup/optaplanner/pull/899
* etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* for a <b>pull request build</b> please add comment: <b>Jenkins retest this</b>
* for a <b>specific pull request build</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
* for a <b>compile downstream build</b> please add comment: <b>Jenkins run cdb</b>
* for a <b>full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
* for an <b>upstream build</b> please add comment: <b>Jenkins run upstream</b>
* for a <b>Quarkus LTS check</b> please add comment: <b>Jenkins run LTS</b>
* for a <b>specific Quarkus LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] LTS</b>
* for a <b>Native check</b> please add comment: <b>Jenkins run native</b>
* for a <b>specific Native LTS check</b> please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|kogito-examples|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>
</details>
