### PR TITLE
Fix a few typos

### DIFF
--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/change/ProblemChangeDirector.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/solver/change/ProblemChangeDirector.java
@@ -49,7 +49,7 @@ public interface ProblemChangeDirector {
      * Remove an existing {@link PlanningEntity} instance from the {@link PlanningSolution working solution}.
      * Translates the entity to a working planning entity by performing a lookup as defined by
      * {@link #lookUpWorkingObjectOrFail(Object)}.
-     * 
+     *
      * @param entity never null; the {@link PlanningEntity} instance
      * @param entityConsumer never null; removes the working entity from the {@link PlanningSolution working solution}
      * @param <Entity> the planning entity object type
@@ -62,8 +62,7 @@ public interface ProblemChangeDirector {
      *
      * @param entity never null; the {@link PlanningEntity} instance
      * @param variableName never null; name of the {@link PlanningVariable}
-     * @param entityConsumer never null; updates the value of the the {@link PlanningVariable} inside
-     *        the {@link PlanningEntity}
+     * @param entityConsumer never null; updates the value of the {@link PlanningVariable} inside the {@link PlanningEntity}
      * @param <Entity> the planning entity object type
      */
     <Entity> void changeVariable(Entity entity, String variableName, Consumer<Entity> entityConsumer);

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/scope/ConstructionHeuristicStepScope.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/constructionheuristic/scope/ConstructionHeuristicStepScope.java
@@ -63,7 +63,7 @@ public class ConstructionHeuristicStepScope<Solution_> extends AbstractStepScope
     }
 
     /**
-     * @return null if logging level is to high
+     * @return null if logging level is too high
      */
     public String getStepString() {
         return stepString;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/lookup/NoneLookUpStrategy.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/lookup/NoneLookUpStrategy.java
@@ -38,7 +38,7 @@ public class NoneLookUpStrategy implements LookUpStrategy {
     public <E> E lookUpWorkingObject(Map<Object, Object> idToWorkingObjectMap, E externalObject) {
         throw new IllegalArgumentException("The externalObject (" + externalObject
                 + ") cannot be looked up. Some functionality, such as multithreaded solving, requires this ability.\n"
-                + "Maybe add an @" + PlanningId.class.getSimpleName()
+                + "Maybe add a @" + PlanningId.class.getSimpleName()
                 + " annotation on an identifier property of the class (" + externalObject.getClass() + ").\n"
                 + "Or otherwise, maybe change the @" + PlanningSolution.class.getSimpleName() + " annotation's "
                 + LookUpStrategyType.class.getSimpleName() + " (not recommended).");
@@ -48,7 +48,7 @@ public class NoneLookUpStrategy implements LookUpStrategy {
     public <E> E lookUpWorkingObjectIfExists(Map<Object, Object> idToWorkingObjectMap, E externalObject) {
         throw new IllegalArgumentException("The externalObject (" + externalObject
                 + ") cannot be looked up. Some functionality, such as multithreaded solving, requires this ability.\n"
-                + "Maybe add an @" + PlanningId.class.getSimpleName()
+                + "Maybe add a @" + PlanningId.class.getSimpleName()
                 + " annotation on an identifier property of the class (" + externalObject.getClass() + ").\n"
                 + "Or otherwise, maybe change the @" + PlanningSolution.class.getSimpleName() + " annotation's "
                 + LookUpStrategyType.class.getSimpleName() + " (not recommended).");

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/domain/solution/descriptor/SolutionDescriptor.java
@@ -213,7 +213,7 @@ public class SolutionDescriptor<Solution_> {
             List<Member> memberList = ConfigUtils.getDeclaredMembers(lineageClass);
             for (Member member : memberList) {
                 if (member instanceof Method && potentiallyOverwritingMethodList.stream().anyMatch(
-                        m -> member.getName().equals(m.getName()) // Short cut to discard negatives faster
+                        m -> member.getName().equals(m.getName()) // Shortcut to discard negatives faster
                                 && ReflectionHelper.isMethodOverwritten((Method) member, m.getDeclaringClass()))) {
                     // Ignore member because it is an overwritten method
                     continue;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/localsearch/scope/LocalSearchStepScope.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/localsearch/scope/LocalSearchStepScope.java
@@ -65,7 +65,7 @@ public class LocalSearchStepScope<Solution_> extends AbstractStepScope<Solution_
     }
 
     /**
-     * @return null if logging level is to high
+     * @return null if logging level is too high
      */
     public String getStepString() {
         return stepString;

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/partitionedsearch/scope/PartitionedSearchStepScope.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/impl/partitionedsearch/scope/PartitionedSearchStepScope.java
@@ -52,7 +52,7 @@ public class PartitionedSearchStepScope<Solution_> extends AbstractStepScope<Sol
     }
 
     /**
-     * @return null if logging level is to high
+     * @return null if logging level is too high
      */
     public String getStepString() {
         return stepString;

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/solution/cloner/GizmoSolutionClonerTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/domain/solution/cloner/GizmoSolutionClonerTest.java
@@ -111,7 +111,7 @@ class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
     }
 
     // HACK: use public getters/setters of fields so test domain can remain private
-    // TODO: should this another DomainAccessType? DomainAcessType.GIZMO_RELAXED_ACCESS?
+    // TODO: should this be another DomainAccessType? DomainAccessType.GIZMO_RELAXED_ACCESS?
     private GizmoSolutionOrEntityDescriptor generateGizmoSolutionOrEntityDescriptor(SolutionDescriptor solutionDescriptor,
             Class<?> entityClass) {
         Map<Field, GizmoMemberDescriptor> solutionFieldToMemberDescriptor = new HashMap<>();
@@ -141,7 +141,7 @@ class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
                             member = new GizmoMemberDescriptor(name, getterDescriptor, memberDescriptor, declaringClass,
                                     setterDescriptor);
                         } else {
-                            throw new IllegalStateException("Fail to generate GizmoMemberDescriptor for (" + name + "): " +
+                            throw new IllegalStateException("Failed to generate GizmoMemberDescriptor for (" + name + "): " +
                                     "Field is not public and does not have both a getter and a setter.");
                         }
                     }
@@ -167,7 +167,7 @@ class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
     private interface RobotZebra extends Zebra, Robot {
     }
 
-    // This test verify the instanceof comparator works correctly
+    // This test verifies the instanceof comparator works correctly
     @Test
     void instanceOfComparatorTest() {
         Set<Class<?>> classSet = new HashSet<>(Arrays.asList(
@@ -201,7 +201,7 @@ class GizmoSolutionClonerTest extends AbstractSolutionClonerTest {
         assertThat(comparator.compare(Zebra.class, RobotZebra.class)).isGreaterThan(0);
     }
 
-    // This test verify a proper error message is thrown if an extended solution is passed.
+    // This test verifies a proper error message is thrown if an extended solution is passed.
     @Override
     @Test
     void cloneExtendedSolution() {

--- a/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/recaller/BestSolutionRecallerTest.java
+++ b/core/optaplanner-core-impl/src/test/java/org/optaplanner/core/impl/solver/recaller/BestSolutionRecallerTest.java
@@ -42,7 +42,7 @@ class BestSolutionRecallerTest {
         return solverScope;
     }
 
-    private static <Solution_> ConstructionHeuristicStepScope<Solution_> setupConstrunctionHeuristics(
+    private static <Solution_> ConstructionHeuristicStepScope<Solution_> setupConstructionHeuristics(
             SolverScope<Solution_> solverScope) {
         ConstructionHeuristicPhaseScope<Solution_> phaseScope = mock(ConstructionHeuristicPhaseScope.class);
         when(phaseScope.getSolverScope()).thenReturn(solverScope);
@@ -94,7 +94,7 @@ class BestSolutionRecallerTest {
         solverScope.setBestSolution(originalBestSolution);
         solverScope.setBestScore(originalBestScore);
 
-        ConstructionHeuristicStepScope<TestdataSolution> stepScope = setupConstrunctionHeuristics(solverScope);
+        ConstructionHeuristicStepScope<TestdataSolution> stepScope = setupConstructionHeuristics(solverScope);
         TestdataSolution stepSolution = mock(TestdataSolution.class);
         when(solverScope.getScoreDirector().getSolutionDescriptor().getScore(stepSolution)).thenReturn(stepScore);
         when(stepScope.getScore()).thenReturn(stepScore);
@@ -148,7 +148,7 @@ class BestSolutionRecallerTest {
         solverScope.setBestSolution(originalBestSolution);
         solverScope.setBestScore(originalBestScore);
 
-        ConstructionHeuristicStepScope<TestdataSolution> stepScope = setupConstrunctionHeuristics(solverScope);
+        ConstructionHeuristicStepScope<TestdataSolution> stepScope = setupConstructionHeuristics(solverScope);
 
         TestdataSolution moveSolution = mock(TestdataSolution.class);
         when(solverScope.getScoreDirector().getSolutionDescriptor().getScore(moveSolution))

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/OptaPlannerProcessor.java
@@ -244,7 +244,7 @@ class OptaPlannerProcessor {
             reflectiveHierarchyClass.produce(new ReflectiveHierarchyBuildItem.Builder()
                     .type(jandexType)
                     // Ignore only the packages from optaplanner-core
-                    // (Can cause a hard to diagnoise issue when creating a test/example
+                    // (Can cause a hard to diagnose issue when creating a test/example
                     // in the package "org.optaplanner").
                     .ignoreTypePredicate(
                             dotName -> ReflectiveHierarchyBuildItem.DefaultIgnoreTypePredicate.INSTANCE.test(dotName)


### PR DESCRIPTION
<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] quarkus-branch</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [optaplanner|kogito-apps|optaplanner-quickstarts|optaweb-employee-rostering|optaweb-vehicle-routing] mandrel</b>
</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://kiegroup.github.io/optaplanner/).