### PR TITLE
[10.0.x] NO-ISSUE: Setup nexus credentials to build parent modules

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -406,12 +406,16 @@ MavenCommand getOptaplannerQuickstartsMavenCommand() {
  * Builds the parent modules and the BOM so that project depending on these artifacts can resolve.
  */
 void mavenCleanInstallOptaPlannerParents() {
-    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]) {
-        getOptaplannerMavenCommand()
-                .skipTests(true)
-                .withOptions(['-U', '-pl org.optaplanner:optaplanner-build-parent,org.optaplanner:optaplanner-bom', '-am'])
-                .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
-                .run('clean install')
+    withCredentials([usernamePassword(credentialsId: env.MAVEN_REPO_CREDS_ID, usernameVariable: 'REPOSITORY_USER', passwordVariable: 'REPOSITORY_TOKEN')]) {
+        configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]) {
+            getOptaplannerMavenCommand()
+                    .skipTests(true)
+                    .withOptions(['-U', '-pl org.optaplanner:optaplanner-build-parent,org.optaplanner:optaplanner-bom', '-am'])
+                    .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                    .withProperty('apache.repository.username', "${REPOSITORY_USER}")
+                    .withProperty('apache.repository.password', "${REPOSITORY_TOKEN}")
+                    .run('clean install')
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds the nexus credentials for the staging repository to fix the following error during the build:

`[ERROR] [ERROR] Some problems were encountered while processing the POMs:
13:32:45  [ERROR] Non-resolvable import POM: The following artifacts could not be resolved: org.drools:drools-bom:pom:10.0.0 (absent): Could not transfer artifact org.drools:drools-bom:pom:10.0.0 from/to apache-staging-repository (https://repository.apache.org/service/local/staging/deploy/maven2): status code: 401, reason phrase: Unauthorized (401) @ line 134, column 19`