### PR TITLE
Switch to using @ConfigMapping interfaces

### DIFF
--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/pom.xml
@@ -108,9 +108,6 @@
               <version>${version.io.quarkus}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/main/java/org/optaplanner/benchmark/quarkus/deployment/OptaPlannerBenchmarkBuildTimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/main/java/org/optaplanner/benchmark/quarkus/deployment/OptaPlannerBenchmarkBuildTimeConfig.java
@@ -21,21 +21,22 @@ package org.optaplanner.benchmark.quarkus.deployment;
 
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
 
 /**
  * During build time, this is translated into OptaPlanner's Config classes.
  */
-@ConfigRoot(name = "optaplanner.benchmark")
-public class OptaPlannerBenchmarkBuildTimeConfig {
+@ConfigRoot
+@ConfigMapping(prefix = "quarkus.optaplanner.benchmark")
+public interface OptaPlannerBenchmarkBuildTimeConfig {
 
     public static final String DEFAULT_SOLVER_BENCHMARK_CONFIG_URL = "solverBenchmarkConfig.xml";
+
     /**
      * A classpath resource to read the benchmark configuration XML.
      * Defaults to {@value DEFAULT_SOLVER_BENCHMARK_CONFIG_URL}.
      * If this property isn't specified, that solverBenchmarkConfig.xml is optional.
      */
-    @ConfigItem
-    Optional<String> solverBenchmarkConfigXml;
+    Optional<String> solverBenchmarkConfigXml();
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/main/java/org/optaplanner/benchmark/quarkus/deployment/OptaPlannerBenchmarkProcessor.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/main/java/org/optaplanner/benchmark/quarkus/deployment/OptaPlannerBenchmarkProcessor.java
@@ -52,13 +52,13 @@ class OptaPlannerBenchmarkProcessor {
 
     @BuildStep
     HotDeploymentWatchedFileBuildItem watchSolverBenchmarkConfigXml() {
-        String solverBenchmarkConfigXML = optaPlannerBenchmarkBuildTimeConfig.solverBenchmarkConfigXml
+        String solverBenchmarkConfigXML = optaPlannerBenchmarkBuildTimeConfig.solverBenchmarkConfigXml()
                 .orElse(OptaPlannerBenchmarkBuildTimeConfig.DEFAULT_SOLVER_BENCHMARK_CONFIG_URL);
         return new HotDeploymentWatchedFileBuildItem(solverBenchmarkConfigXML);
     }
 
     @BuildStep
-    @Record(ExecutionTime.STATIC_INIT)
+    @Record(ExecutionTime.RUNTIME_INIT)
     void registerAdditionalBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans,
             BuildProducer<UnremovableBeanBuildItem> unremovableBeans,
@@ -71,8 +71,8 @@ class OptaPlannerBenchmarkProcessor {
         }
         PlannerBenchmarkConfig benchmarkConfig;
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        if (optaPlannerBenchmarkBuildTimeConfig.solverBenchmarkConfigXml.isPresent()) {
-            String solverBenchmarkConfigXML = optaPlannerBenchmarkBuildTimeConfig.solverBenchmarkConfigXml.get();
+        if (optaPlannerBenchmarkBuildTimeConfig.solverBenchmarkConfigXml().isPresent()) {
+            String solverBenchmarkConfigXML = optaPlannerBenchmarkBuildTimeConfig.solverBenchmarkConfigXml().get();
             if (classLoader.getResource(solverBenchmarkConfigXML) == null) {
                 throw new ConfigurationException("Invalid quarkus.optaplanner.benchmark.solver-benchmark-config-xml property ("
                         + solverBenchmarkConfigXML + "): that classpath resource does not exist.");
@@ -85,6 +85,7 @@ class OptaPlannerBenchmarkProcessor {
             benchmarkConfig = null;
         }
         syntheticBeans.produce(SyntheticBeanBuildItem.configure(PlannerBenchmarkConfig.class)
+                .setRuntimeInit()
                 .supplier(recorder.benchmarkConfigSupplier(benchmarkConfig))
                 .done());
         additionalBeans.produce(new AdditionalBeanBuildItem(OptaPlannerBenchmarkBeanProvider.class));

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitPerBenchmarkTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitPerBenchmarkTest.java
@@ -21,6 +21,8 @@ package org.optaplanner.benchmark.quarkus;
 
 import java.util.concurrent.ExecutionException;
 
+import jakarta.inject.Inject;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
@@ -28,10 +30,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
 import org.optaplanner.benchmark.config.SolverBenchmarkConfig;
+import org.optaplanner.benchmark.quarkus.config.OptaPlannerBenchmarkRuntimeConfig;
 import org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
 import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.test.QuarkusUnitTest;
 
 class OptaPlannerBenchmarkProcessorMissingSpentLimitPerBenchmarkTest {
@@ -46,12 +50,16 @@ class OptaPlannerBenchmarkProcessorMissingSpentLimitPerBenchmarkTest {
                             TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class)
                     .addAsResource("solverBenchmarkConfigSpentLimitPerBenchmarkNoTermination.xml"));
 
+    @Inject
+    OptaPlannerBenchmarkRuntimeConfig optaPlannerBenchmarkRuntimeConfig;
+
     @Test
     void benchmark() throws ExecutionException, InterruptedException {
         PlannerBenchmarkConfig benchmarkConfig =
                 PlannerBenchmarkConfig.createFromXmlResource("solverBenchmarkConfigSpentLimitPerBenchmarkNoTermination.xml");
         IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> {
-            new OptaPlannerBenchmarkRecorder().benchmarkConfigSupplier(benchmarkConfig).get();
+            new OptaPlannerBenchmarkRecorder(new RuntimeValue<>(optaPlannerBenchmarkRuntimeConfig))
+                    .benchmarkConfigSupplier(benchmarkConfig).get();
         });
         Assertions.assertEquals(
                 "The following " + SolverBenchmarkConfig.class.getSimpleName() + " do not " +

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitTest.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/deployment/src/test/java/org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkProcessorMissingSpentLimitTest.java
@@ -21,16 +21,20 @@ package org.optaplanner.benchmark.quarkus;
 
 import java.util.concurrent.ExecutionException;
 
+import jakarta.inject.Inject;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.optaplanner.benchmark.config.PlannerBenchmarkConfig;
+import org.optaplanner.benchmark.quarkus.config.OptaPlannerBenchmarkRuntimeConfig;
 import org.optaplanner.benchmark.quarkus.testdata.normal.constraints.TestdataQuarkusConstraintProvider;
 import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusEntity;
 import org.optaplanner.benchmark.quarkus.testdata.normal.domain.TestdataQuarkusSolution;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.test.QuarkusUnitTest;
 
 class OptaPlannerBenchmarkProcessorMissingSpentLimitTest {
@@ -42,10 +46,14 @@ class OptaPlannerBenchmarkProcessorMissingSpentLimitTest {
                     .addClasses(TestdataQuarkusEntity.class,
                             TestdataQuarkusSolution.class, TestdataQuarkusConstraintProvider.class));
 
+    @Inject
+    OptaPlannerBenchmarkRuntimeConfig optaPlannerBenchmarkRuntimeConfig;
+
     @Test
     void benchmark() throws ExecutionException, InterruptedException {
         IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> {
-            new OptaPlannerBenchmarkRecorder().benchmarkConfigSupplier(new PlannerBenchmarkConfig()).get();
+            new OptaPlannerBenchmarkRecorder(new RuntimeValue<>(optaPlannerBenchmarkRuntimeConfig))
+                    .benchmarkConfigSupplier(new PlannerBenchmarkConfig()).get();
         });
         Assertions.assertEquals(
                 "At least one of the properties quarkus.optaplanner.benchmark.solver.termination.spent-limit, quarkus.optaplanner.benchmark.solver.termination.best-score-limit, quarkus.optaplanner.benchmark.solver.termination.unimproved-spent-limit is required if termination is not configured in the inherited solver benchmark config and solverBenchmarkBluePrint is used.",

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/pom.xml
@@ -96,9 +96,6 @@
               <version>${version.io.quarkus}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/config/OptaPlannerBenchmarkRuntimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-benchmark/runtime/src/main/java/org/optaplanner/benchmark/quarkus/config/OptaPlannerBenchmarkRuntimeConfig.java
@@ -21,24 +21,27 @@ package org.optaplanner.benchmark.quarkus.config;
 
 import org.optaplanner.quarkus.config.TerminationRuntimeConfig;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
-@ConfigRoot(name = "optaplanner.benchmark", phase = ConfigPhase.RUN_TIME)
-public class OptaPlannerBenchmarkRuntimeConfig {
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "quarkus.optaplanner.benchmark")
+public interface OptaPlannerBenchmarkRuntimeConfig {
     public static final String DEFAULT_BENCHMARK_RESULT_DIRECTORY = "target/benchmarks";
 
     /**
      * Where the benchmark results are written to. Defaults to
      * {@link DEFAULT_BENCHMARK_RESULT_DIRECTORY}.
      */
-    @ConfigItem(defaultValue = DEFAULT_BENCHMARK_RESULT_DIRECTORY)
-    public String resultDirectory;
+    @WithDefault(DEFAULT_BENCHMARK_RESULT_DIRECTORY)
+    String resultDirectory();
 
     /**
      * Termination configuration for the solvers run in the benchmark.
      */
-    @ConfigItem(name = "solver.termination")
-    public TerminationRuntimeConfig termination;
+    @WithName("solver.termination")
+    TerminationRuntimeConfig termination();
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/deployment/pom.xml
@@ -73,9 +73,6 @@
               <version>${version.io.quarkus}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
     </plugins>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jackson/runtime/pom.xml
@@ -91,9 +91,6 @@
               <version>${version.io.quarkus}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/deployment/pom.xml
@@ -73,9 +73,6 @@
               <version>${version.io.quarkus}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
     </plugins>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus-jsonb/runtime/pom.xml
@@ -92,9 +92,6 @@
               <version>${version.io.quarkus}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
     </plugins>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/pom.xml
@@ -106,9 +106,6 @@
               <version>${version.io.quarkus}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/config/OptaPlannerBuildTimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/config/OptaPlannerBuildTimeConfig.java
@@ -26,14 +26,15 @@ import org.optaplanner.core.api.score.calculator.IncrementalScoreCalculator;
 import org.optaplanner.core.api.score.stream.ConstraintProvider;
 import org.optaplanner.core.config.solver.SolverConfig;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
 
 /**
  * During build time, this is translated into OptaPlanner's Config classes.
  */
-@ConfigRoot(name = "optaplanner")
-public class OptaPlannerBuildTimeConfig {
+@ConfigRoot
+@ConfigMapping(prefix = "quarkus.optaplanner")
+public interface OptaPlannerBuildTimeConfig {
 
     public static final String DEFAULT_SOLVER_CONFIG_URL = "solverConfig.xml";
     public static final String DEFAULT_CONSTRAINTS_DRL_URL = "constraints.drl";
@@ -44,8 +45,7 @@ public class OptaPlannerBuildTimeConfig {
      * Defaults to {@value DEFAULT_SOLVER_CONFIG_URL}.
      * If this property isn't specified, that solverConfig.xml is optional.
      */
-    @ConfigItem
-    public Optional<String> solverConfigXml;
+    Optional<String> solverConfigXml();
 
     /**
      * A classpath resource to read the solver score DRL.
@@ -53,13 +53,11 @@ public class OptaPlannerBuildTimeConfig {
      * Do not define this property when a {@link ConstraintProvider}, {@link EasyScoreCalculator} or
      * {@link IncrementalScoreCalculator} class exists.
      */
-    @ConfigItem
-    public Optional<String> scoreDrl;
+    Optional<String> scoreDrl();
 
     /**
      * Configuration properties that overwrite OptaPlanner's {@link SolverConfig}.
      */
-    @ConfigItem
-    public SolverBuildTimeConfig solver;
+    SolverBuildTimeConfig solver();
 
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/config/SolverBuildTimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/deployment/src/main/java/org/optaplanner/quarkus/deployment/config/SolverBuildTimeConfig.java
@@ -28,7 +28,6 @@ import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.quarkus.config.SolverRuntimeConfig;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 
 /**
  * During build time, this is translated into OptaPlanner's {@link SolverConfig}
@@ -37,34 +36,30 @@ import io.quarkus.runtime.annotations.ConfigItem;
  * See also {@link SolverRuntimeConfig}
  */
 @ConfigGroup
-public class SolverBuildTimeConfig {
+public interface SolverBuildTimeConfig {
 
     /**
      * Enable runtime assertions to detect common bugs in your implementation during development.
      * Defaults to {@link EnvironmentMode#REPRODUCIBLE}.
      */
-    @ConfigItem
-    public Optional<EnvironmentMode> environmentMode;
+    Optional<EnvironmentMode> environmentMode();
 
     /**
      * Enable daemon mode. In daemon mode, non-early termination pauses the solver instead of stopping it,
      * until the next problem fact change arrives. This is often useful for real-time planning.
      * Defaults to "false".
      */
-    @ConfigItem
-    public Optional<Boolean> daemon;
+    Optional<Boolean> daemon();
 
     /**
      * Determines how to access the fields and methods of domain classes.
      * Defaults to {@link DomainAccessType#GIZMO}.
      */
-    @ConfigItem
-    public Optional<DomainAccessType> domainAccessType;
+    Optional<DomainAccessType> domainAccessType();
 
     /**
      * What constraint stream implementation to use. Defaults to {@link ConstraintStreamImplType#DROOLS}.
      */
-    @ConfigItem
-    public Optional<ConstraintStreamImplType> constraintStreamImplType;
+    Optional<ConstraintStreamImplType> constraintStreamImplType();
 
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/pom.xml
@@ -104,9 +104,6 @@
               <version>${version.io.quarkus}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <arg>-AlegacyConfigRoot=true</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/OptaPlannerRuntimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/OptaPlannerRuntimeConfig.java
@@ -22,22 +22,21 @@ package org.optaplanner.quarkus.config;
 import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.SolverManagerConfig;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
 
-@ConfigRoot(name = "optaplanner", phase = ConfigPhase.RUN_TIME)
-public class OptaPlannerRuntimeConfig {
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "quarkus.optaplanner")
+public interface OptaPlannerRuntimeConfig {
     /**
      * During run time, this is translated into OptaPlanner's {@link SolverConfig}
      * runtime properties.
      */
-    @ConfigItem
-    public SolverRuntimeConfig solver;
+    SolverRuntimeConfig solver();
 
     /**
      * Configuration properties that overwrite OptaPlanner's {@link SolverManagerConfig}.
      */
-    @ConfigItem
-    public SolverManagerRuntimeConfig solverManager;
+    SolverManagerRuntimeConfig solverManager();
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/SolverManagerRuntimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/SolverManagerRuntimeConfig.java
@@ -24,20 +24,18 @@ import java.util.Optional;
 import org.optaplanner.core.config.solver.SolverManagerConfig;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 
 /**
  * During build time, this is translated into OptaPlanner's {@link SolverManagerConfig}.
  */
 @ConfigGroup
-public class SolverManagerRuntimeConfig {
+public interface SolverManagerRuntimeConfig {
 
     /**
      * The number of solvers that run in parallel. This directly influences CPU consumption.
      * Defaults to {@value SolverManagerConfig#PARALLEL_SOLVER_COUNT_AUTO}.
      * Other options include a number or formula based on the available processor count.
      */
-    @ConfigItem
-    public Optional<String> parallelSolverCount;
+    public Optional<String> parallelSolverCount();
 
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/SolverRuntimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/SolverRuntimeConfig.java
@@ -25,26 +25,23 @@ import org.optaplanner.core.config.solver.SolverConfig;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 
 /**
  * During run time, this overrides some of OptaPlanner's {@link SolverConfig}
  * properties.
  */
 @ConfigGroup
-public class SolverRuntimeConfig {
+public interface SolverRuntimeConfig {
     /**
      * Enable multithreaded solving for a single problem, which increases CPU consumption.
      * Defaults to {@value SolverConfig#MOVE_THREAD_COUNT_NONE}.
      * Other options include {@value SolverConfig#MOVE_THREAD_COUNT_AUTO}, a number
      * or formula based on the available processor count.
      */
-    @ConfigItem
-    public Optional<String> moveThreadCount;
+    public Optional<String> moveThreadCount();
 
     /**
      * Configuration properties that overwrite OptaPlanner's {@link TerminationConfig}.
      */
-    @ConfigItem
-    public TerminationRuntimeConfig termination;
+    public TerminationRuntimeConfig termination();
 }

--- a/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/TerminationRuntimeConfig.java
+++ b/optaplanner-quarkus-integration/optaplanner-quarkus/runtime/src/main/java/org/optaplanner/quarkus/config/TerminationRuntimeConfig.java
@@ -25,35 +25,33 @@ import java.util.Optional;
 import org.optaplanner.core.config.solver.termination.TerminationConfig;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 
 /**
  * During build time, this is translated into OptaPlanner's {@link TerminationConfig}.
  */
 @ConfigGroup
-public class TerminationRuntimeConfig {
+public interface TerminationRuntimeConfig {
 
     /**
      * How long the solver can run.
      * For example: "30s" is 30 seconds. "5m" is 5 minutes. "2h" is 2 hours. "1d" is 1 day.
      * Also supports ISO-8601 format, see {@link Duration}.
      */
-    @ConfigItem
-    public Optional<Duration> spentLimit;
+    Optional<Duration> spentLimit();
+
     /**
      * How long the solver can run without finding a new best solution after finding a new best solution.
      * For example: "30s" is 30 seconds. "5m" is 5 minutes. "2h" is 2 hours. "1d" is 1 day.
      * Also supports ISO-8601 format, see {@link Duration}.
      */
-    @ConfigItem
-    public Optional<Duration> unimprovedSpentLimit;
+    Optional<Duration> unimprovedSpentLimit();
+
     /**
      * Terminates the solver when a specific or higher score has been reached.
      * For example: "0hard/-1000soft" terminates when the best score changes from "0hard/-1200soft" to "0hard/-900soft".
      * Wildcards are supported to replace numbers.
      * For example: "0hard/*soft" to terminate when any feasible score is reached.
      */
-    @ConfigItem
-    public Optional<String> bestScoreLimit;
+    Optional<String> bestScoreLimit();
 
 }


### PR DESCRIPTION
Legacy @ConfigRoot classes support will be dropped soon from Quarkus and Quarkus 3.15+ already supports @ConfigMapping interfaces so we can move this project to the new infrastructure.

One thing that is important is that you are currently using runtime config at static init - which means that it's build time for native images and this is not correct - and disallowed.

I fixed it but the important consequence of this is that the solver will be initialized at runtime, including when building native image.

This commit is still incomplete though as I end up with some class loader issues and I didn't have the time to go further.

Here is the class loader issue I end up with with my changes. It might be a dumb mistake but what I thought would be a simple change ended up being a bit of a rabbit hole so I'm leaving it at that. Creating the PR as I thought someone might be interested to pursue it further.

```
[ERROR] org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkProcessorBenchmarkConfigTest  Time elapsed: 0.593 s  <<< ERROR!
org.junit.jupiter.api.extension.TestInstantiationException: Failed to create test instance
	at io.quarkus.test.QuarkusUnitTest.beforeAll(QuarkusUnitTest.java:716)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at io.quarkus.runner.bootstrap.RunningQuarkusApplicationImpl.instance(RunningQuarkusApplicationImpl.java:90)
	at io.quarkus.test.QuarkusUnitTest.beforeAll(QuarkusUnitTest.java:708)
	... 1 more
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at io.quarkus.runner.bootstrap.RunningQuarkusApplicationImpl.instance(RunningQuarkusApplicationImpl.java:88)
	... 2 more
Caused by: java.lang.LinkageError: loader constraint violation: when resolving method 'void org.optaplanner.benchmark.config.SolverBenchmarkConfig.setSolverConfig(org.optaplanner.core.config.solver.SolverConfig)' the class loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @3f350e2b of the current class, org/optaplanner/benchmark/quarkus/OptaPlannerBenchmarkRecorder, and the class loader 'app' for the method's defining class, org/optaplanner/benchmark/config/SolverBenchmarkConfig, have different Class objects for the type org/optaplanner/core/config/solver/SolverConfig used in the signature (org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkRecorder is in unnamed module of loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @3f350e2b, parent loader io.quarkus.bootstrap.classloading.QuarkusClassLoader @5dfe144; org.optaplanner.benchmark.config.SolverBenchmarkConfig is in unnamed module of loader 'app')
	at org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkRecorder.updateBenchmarkConfigWithRuntimeProperties(OptaPlannerBenchmarkRecorder.java:78)
	at org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkRecorder.lambda$benchmarkConfigSupplier$0(OptaPlannerBenchmarkRecorder.java:57)
	at io.quarkus.arc.runtime.ArcRecorder$4.apply(ArcRecorder.java:137)
	at io.quarkus.arc.runtime.ArcRecorder$4.apply(ArcRecorder.java:134)
	at org.optaplanner.benchmark.config.PlannerBenchmarkConfig_jQ0LrSuk-Q8ejoc5zd7QE0_QkLU_Synthetic_Bean.createSynthetic(Unknown Source)
	at org.optaplanner.benchmark.config.PlannerBenchmarkConfig_jQ0LrSuk-Q8ejoc5zd7QE0_QkLU_Synthetic_Bean.doCreate(Unknown Source)
	at org.optaplanner.benchmark.config.PlannerBenchmarkConfig_jQ0LrSuk-Q8ejoc5zd7QE0_QkLU_Synthetic_Bean.create(Unknown Source)
	at org.optaplanner.benchmark.config.PlannerBenchmarkConfig_jQ0LrSuk-Q8ejoc5zd7QE0_QkLU_Synthetic_Bean.get(Unknown Source)
	at org.optaplanner.benchmark.config.PlannerBenchmarkConfig_jQ0LrSuk-Q8ejoc5zd7QE0_QkLU_Synthetic_Bean.get(Unknown Source)
	at io.quarkus.arc.impl.CurrentInjectionPointProvider.get(CurrentInjectionPointProvider.java:48)
	at org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkBeanProvider_ProducerMethod_benchmarkFactory_rQ7QoTazk6Wv0BPV1PrJ986ZnAc_Bean.doCreate(Unknown Source)
	at org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkBeanProvider_ProducerMethod_benchmarkFactory_rQ7QoTazk6Wv0BPV1PrJ986ZnAc_Bean.create(Unknown Source)
	at org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkBeanProvider_ProducerMethod_benchmarkFactory_rQ7QoTazk6Wv0BPV1PrJ986ZnAc_Bean.create(Unknown Source)
	at io.quarkus.arc.impl.AbstractSharedContext.createInstanceHandle(AbstractSharedContext.java:119)
	at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:38)
	at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:35)
	at io.quarkus.arc.impl.LazyValue.get(LazyValue.java:32)
	at io.quarkus.arc.impl.ComputingCache.computeIfAbsent(ComputingCache.java:69)
	at io.quarkus.arc.impl.ComputingCacheContextInstances.computeIfAbsent(ComputingCacheContextInstances.java:19)
	at io.quarkus.arc.impl.AbstractSharedContext.get(AbstractSharedContext.java:35)
	at org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkBeanProvider_ProducerMethod_benchmarkFactory_rQ7QoTazk6Wv0BPV1PrJ986ZnAc_Bean.get(Unknown Source)
	at org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkBeanProvider_ProducerMethod_benchmarkFactory_rQ7QoTazk6Wv0BPV1PrJ986ZnAc_Bean.get(Unknown Source)
	at org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkProcessorBenchmarkConfigTest_Bean.doCreate(Unknown Source)
	at org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkProcessorBenchmarkConfigTest_Bean.create(Unknown Source)
	at org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkProcessorBenchmarkConfigTest_Bean.get(Unknown Source)
	at org.optaplanner.benchmark.quarkus.OptaPlannerBenchmarkProcessorBenchmarkConfigTest_Bean.get(Unknown Source)
	at io.quarkus.arc.impl.InstanceImpl.getBeanInstance(InstanceImpl.java:325)
	at io.quarkus.arc.impl.InstanceImpl.getInternal(InstanceImpl.java:309)
	at io.quarkus.arc.impl.InstanceImpl.get(InstanceImpl.java:190)

```