### PR TITLE
Add `forEachUniquePairIncludingNullVars`

### DIFF
--- a/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/InnerConstraintFactory.java
+++ b/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/InnerConstraintFactory.java
@@ -73,17 +73,11 @@ public abstract class InnerConstraintFactory<Solution_, Constraint_ extends Cons
     }
 
     @Override
-    public <A> BiConstraintStream<A, A> forEachUniquePair(Class<A> sourceClass, boolean includingNullVars, boolean noIdJoiner,
-            BiJoiner<A, A>... joiners) {
+    public <A> BiConstraintStream<A, A> forEachUniquePairIncludingNullVars(Class<A> sourceClass, BiJoiner<A, A>... joiners) {
         BiJoinerComber<A, A> joinerComber = BiJoinerComber.comb(joiners);
-        if (!noIdJoiner) {
-            joinerComber.addJoiner(buildLessThanId(sourceClass));
-        }
-
-        return includingNullVars
-                ? ((InnerUniConstraintStream<A>) forEachIncludingNullVars(sourceClass)).join(
-                        forEachIncludingNullVars(sourceClass), joinerComber)
-                : ((InnerUniConstraintStream<A>) forEach(sourceClass)).join(forEach(sourceClass), joinerComber);
+        joinerComber.addJoiner(buildLessThanId(sourceClass));
+        return ((InnerUniConstraintStream<A>) forEachIncludingNullVars(sourceClass)).join(
+                forEachIncludingNullVars(sourceClass), joinerComber);
 
     }
 

--- a/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/InnerConstraintFactory.java
+++ b/core/optaplanner-constraint-streams-common/src/main/java/org/optaplanner/constraint/streams/common/InnerConstraintFactory.java
@@ -72,6 +72,21 @@ public abstract class InnerConstraintFactory<Solution_, Constraint_ extends Cons
                 .join(forEach(sourceClass), joinerComber);
     }
 
+    @Override
+    public <A> BiConstraintStream<A, A> forEachUniquePair(Class<A> sourceClass, boolean includingNullVars, boolean noIdJoiner,
+            BiJoiner<A, A>... joiners) {
+        BiJoinerComber<A, A> joinerComber = BiJoinerComber.comb(joiners);
+        if (!noIdJoiner) {
+            joinerComber.addJoiner(buildLessThanId(sourceClass));
+        }
+
+        return includingNullVars
+                ? ((InnerUniConstraintStream<A>) forEachIncludingNullVars(sourceClass)).join(
+                        forEachIncludingNullVars(sourceClass), joinerComber)
+                : ((InnerUniConstraintStream<A>) forEach(sourceClass)).join(forEach(sourceClass), joinerComber);
+
+    }
+
     private <A> DefaultBiJoiner<A, A> buildLessThanId(Class<A> sourceClass) {
         SolutionDescriptor<Solution_> solutionDescriptor = getSolutionDescriptor();
         MemberAccessor planningIdMemberAccessor =

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/stream/ConstraintFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/stream/ConstraintFactory.java
@@ -180,6 +180,24 @@ public interface ConstraintFactory {
      */
     <A> BiConstraintStream<A, A> forEachUniquePair(Class<A> sourceClass, BiJoiner<A, A>... joiners);
 
+    /**
+     * Create a new {@link BiConstraintStream} for every unique combination of A and another A, optionally with a higher
+     * {@link PlanningId} for which the {@link BiJoiner} is true (for the properties it extracts from both facts).
+     * <p>
+     * This method causes <i>Unchecked generics array creation for varargs parameter</i> warnings,
+     * but we can't fix it with a {@link SafeVarargs} annotation because it's an interface method.
+     *
+     * @param sourceClass never null
+     * @param includingNullVars include facts with null variables
+     * @param noIdJoiner do not add a {@link Joiners#lessThan(Function) lessThan} joiner on the {@link PlanningId} of A
+     * @param joiners never null
+     * @param <A> the type of the matched problem fact or {@link PlanningEntity planning entity}
+     * @return a stream that matches every unique combination of A and another A for which all the
+     *         {@link BiJoiner joiners} are true
+     */
+    <A> BiConstraintStream<A, A> forEachUniquePair(Class<A> sourceClass, boolean includingNullVars, boolean noIdJoiner,
+            BiJoiner<A, A>... joiners);
+
     // ************************************************************************
     // from* (deprecated)
     // ************************************************************************

--- a/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/stream/ConstraintFactory.java
+++ b/core/optaplanner-core-impl/src/main/java/org/optaplanner/core/api/score/stream/ConstraintFactory.java
@@ -181,22 +181,19 @@ public interface ConstraintFactory {
     <A> BiConstraintStream<A, A> forEachUniquePair(Class<A> sourceClass, BiJoiner<A, A>... joiners);
 
     /**
-     * Create a new {@link BiConstraintStream} for every unique combination of A and another A, optionally with a higher
-     * {@link PlanningId} for which the {@link BiJoiner} is true (for the properties it extracts from both facts).
+     * this method is identical to {@link #forEachUniquePair(Class, BiJoiner[])},
+     * except that it includes facts with null variables in the result.
      * <p>
      * This method causes <i>Unchecked generics array creation for varargs parameter</i> warnings,
      * but we can't fix it with a {@link SafeVarargs} annotation because it's an interface method.
      *
      * @param sourceClass never null
-     * @param includingNullVars include facts with null variables
-     * @param noIdJoiner do not add a {@link Joiners#lessThan(Function) lessThan} joiner on the {@link PlanningId} of A
      * @param joiners never null
      * @param <A> the type of the matched problem fact or {@link PlanningEntity planning entity}
      * @return a stream that matches every unique combination of A and another A for which all the
      *         {@link BiJoiner joiners} are true
      */
-    <A> BiConstraintStream<A, A> forEachUniquePair(Class<A> sourceClass, boolean includingNullVars, boolean noIdJoiner,
-            BiJoiner<A, A>... joiners);
+    <A> BiConstraintStream<A, A> forEachUniquePairIncludingNullVars(Class<A> sourceClass, BiJoiner<A, A>... joiners);
 
     // ************************************************************************
     // from* (deprecated)


### PR DESCRIPTION
Add a `forEachUniquePair` vararg overload that takes two additional parameters:
- `boolean includingNullVars` - if true, facts with null variables are returned as well. This is useful in cases where you want to e.g. further penalize multiple unscheduled appointments for the same patient.
- `boolean noIdJoiner` - if true, returned facts are not joined based on `id`. This is useful in cases where you want to join facts by a different property.

These two parameters can be replaced by some kind of flags.
I chose `false` values to result in current behavior.
Would make sense to add non-vararg overloads too.

You can work around not having `noIdJoiner` by using `constraintFactory.forEach(sourceClass).join(constraintFactory.forEach(sourceClass), ...)`. 
To work around not having `includingNullVars`, you could use `constraintFactory.forEachIncludingNullVars(sourceClass).join(constraintFactory.forEachIncludingNullVars(sourceClass), ...)`, but you'd also have to expose the id in order to join by it.

Please let me know if I'm missing something and there's a better way to do this.

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
