### PR TITLE
[kie-issues#2306] Update Spring dependencies to 6.2.18 and Spring Boot to 3.5.14

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -57,8 +57,8 @@
     <version.org.jfree.jfreechart>1.5.4</version.org.jfree.jfreechart>
     <version.org.openrewrite.recipe>1.19.3</version.org.openrewrite.recipe>
     <version.org.slf4j>2.0.17</version.org.slf4j><!-- TODO keep in sync with quarkus-bom -->
-    <version.org.springframework>6.2.17</version.org.springframework>
-    <version.org.springframework.boot>3.5.12</version.org.springframework.boot>
+    <version.org.springframework>6.2.18</version.org.springframework>
+    <version.org.springframework.boot>3.5.14</version.org.springframework.boot>
 
     <!-- ************************************************************************ -->
     <!-- Plugins -->


### PR DESCRIPTION
New vulnerabilities have been identified in Spring Boot and the Spring Framework. To address these issues, the following dependency updates are required:
Changes
Spring Framework: 6.2.17 → 6.2.18
Spring Boot: 3.5.12 → 3.5.14
These updates include fixes for the latest reported security vulnerabilities.

Related PR:https://github.com/apache/incubator-kie-kogito-runtimes/pull/4282
https://github.com/apache/incubator-kie-kogito-examples/pull/2211
https://github.com/apache/incubator-kie-tools/pull/3574