### PR TITLE
[NO-ISSUE] Upgrade logback-core to version 1.5.34 to address CVEs

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -42,7 +42,7 @@
     <version.org.drools>${project.version}</version.org.drools>
 
     <!-- Normal dependency versions -->
-    <version.ch.qos.logback>1.5.32</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.34</version.ch.qos.logback>
     <version.org.apache.logging.log4j>2.22.1</version.org.apache.logging.log4j>
     <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
     <version.io.quarkiverse.operatorsdk>6.6.7</version.io.quarkiverse.operatorsdk>


### PR DESCRIPTION
### JIRA

[NO-ISSUE]

### Referenced pull requests

* https://github.com/apache/incubator-kie-drools/pull/6743

### Description

This PR upgrades Logback from `1.5.32` to `1.5.34`.

The shared `version.ch.qos.logback` property is used for both:

* `ch.qos.logback:logback-core`
* `ch.qos.logback:logback-classic`

So both dependencies remain aligned to the same version.

### Changes

Updated:

* `build/optaplanner-build-parent/pom.xml`

Changed:

* From: `1.5.32`
* To: `1.5.34`

### Validation

Verified:

```bash
grep -n "version.ch.qos.logback" build/optaplanner-build-parent/pom.xml
grep -R "1.5.32" build/optaplanner-build-parent/pom.xml
```

Result:

* `version.ch.qos.logback` is updated to `1.5.34`
* `1.5.32` is no longer present in `build/optaplanner-build-parent/pom.xml`

### Checklist

* [ ] Documentation updated if applicable. Not applicable.
* [ ] Release notes updated if applicable. Not applicable.
* [ ] Upgrade recipe provided if applicable. Not applicable.
