### PR TITLE
[CVE] Spring boot Patch version upgrade to 4.0.7

### DIFF
--- a/build/optaplanner-build-parent/pom.xml
+++ b/build/optaplanner-build-parent/pom.xml
@@ -58,7 +58,7 @@
     <version.org.openrewrite.recipe>1.19.3</version.org.openrewrite.recipe>
     <version.org.slf4j>2.0.17</version.org.slf4j><!-- TODO keep in sync with quarkus-bom -->
     <version.org.springframework>7.0.7</version.org.springframework>
-    <version.org.springframework.boot>4.0.6</version.org.springframework.boot>
+    <version.org.springframework.boot>4.0.7</version.org.springframework.boot>
 
     <!-- ************************************************************************ -->
     <!-- Plugins -->


### PR DESCRIPTION
Spring boot version upgrade to fix below CVEs



| Dependency | Critical | High | Medium | Low |
|------------|----------|------|--------|-----|
| spring-web (7.0.7) | - | CVE-2026-41845 | CVE-2026-41839, CVE-2026-41840, CVE-2026-41853, CVE-2026-41854 | - |
| spring-webmvc (7.0.7) | - | CVE-2026-41842 | CVE-2026-41841, CVE-2026-41843, CVE-2026-41844, CVE-2026-41846 | - |
| spring-core (7.0.7) | - | - | - | CVE-2026-41848 |
| spring-expression (7.0.7) | - | CVE-2026-41850 | CVE-2026-41851 | CVE-2026-41852 |
| spring-security-core (7.0.5) | - | CVE-2026-40988 | CVE-2026-41008 | CVE-2026-41694 |
| spring-security-web (7.0.5) | - | - | CVE-2026-41706 | - |
| spring-kafka (4.0.5) | - | CVE-2026-41731 | CVE-2026-41726, CVE-2026-41727 | - |
| spring-data-mongodb (5.0.5) | - | CVE-2026-41717 | CVE-2026-41696 | - |
| spring-data-commons (4.0.5) | - | CVE-2026-41695, CVE-2026-41716 | CVE-2026-41711, CVE-2026-41721 | - |

Kie-Tools: https://github.com/apache/incubator-kie-tools/pull/3631
Runtimes : https://github.com/apache/incubator-kie-kogito-runtimes/pull/4317
Examples: https://github.com/apache/incubator-kie-kogito-examples/pull/2218