### PR TITLE
kie-issues#2347: 10.3.x+ stream: Move optaplanner to drools preserving Git-history and top-level directory structure

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,3 @@
+project:
+  metadata:
+    description: OplaPlanner has moved to https://github.com/apache/incubator-kie-drools. This repository is archived. OptaPlanner is an AI constraint solver in Java to optimize the vehicle routing problem, employee rostering, task assignment, maintenance scheduling, conference scheduling and other planning problems.

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,2 @@
-project:
-  metadata:
-    description: OplaPlanner has moved to https://github.com/apache/incubator-kie-drools. This repository is archived. OptaPlanner is an AI constraint solver in Java to optimize the vehicle routing problem, employee rostering, task assignment, maintenance scheduling, conference scheduling and other planning problems.
+github:
+  description: OplaPlanner has moved to https://github.com/apache/incubator-kie-drools. This repository is archived. OptaPlanner is an AI constraint solver in Java to optimize the vehicle routing problem, employee rostering, task assignment, maintenance scheduling, conference scheduling and other planning problems.

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,5 +1,6 @@
 .rat-excludes
 .rat-reports
+.asf.yaml
 DISCLAIMER-WIP
 build/optaplanner-ide-config/src/main/resources/eclipse.importorder
 core/optaplanner-core-impl/src/main/resources/solver.xsd

--- a/README.adoc
+++ b/README.adoc
@@ -17,33 +17,22 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-:projectKey: org.optaplanner:optaplanner
-:sonarBadge: image:https://sonarcloud.io/api/project_badges/measure?project={projectKey}
-:sonarLink: link="https://sonarcloud.io/dashboard?id={projectKey}"
-
-:branch: main
-
-:jenkinsUrl: https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner
-:branchJenkinsUrl: {jenkinsUrl}/job/{branch}
-:toolsFolderJenkinsUrl: {branchJenkinsUrl}/job/tools
-:releaseFolderJenkinsUrl: {branchJenkinsUrl}/job/release
-
 image::optaplanner-docs/src/modules/ROOT/images/shared/optaPlannerLogo.png[link="https://www.optaplanner.org/",OptaPlanner,150,150,align="center"]
+
+[WARNING]
+====
+*This repository is archived and no longer actively maintained.*
+
+The OptaPlanner codebase has been merged into the https://github.com/apache/incubator-kie-drools[apache/incubator-kie-drools] repository.
+Please use that repository for the latest source code, to file issues, and to submit contributions.
+====
 
 image:https://img.shields.io/maven-central/v/org.optaplanner/optaplanner-bom?logo=apache-maven&style=for-the-badge["Maven artifact", link="https://ossindex.sonatype.org/component/pkg:maven/org.optaplanner/optaplanner-bom"]
 image:https://img.shields.io/badge/stackoverflow-ask_question-orange.svg?logo=stackoverflow&style=for-the-badge["Stackoverflow", link="https://stackoverflow.com/questions/tagged/optaplanner"]
 image:https://img.shields.io/badge/zulip-join_chat-brightgreen.svg?logo=zulip&style=for-the-badge[
 "Join Zulip Chat", link="https://kie.zulipchat.com/#narrow/stream/232679-optaplanner"]
-image:https://img.shields.io/github/commit-activity/m/kiegroup/optaplanner?label=commits&style=for-the-badge["Commit Activity", link="https://github.com/kiegroup/optaplanner/pulse"]
-image:https://img.shields.io/github/license/kiegroup/optaplanner?style=for-the-badge&logo=apache["Livense", link="https://www.apache.org/licenses/LICENSE-2.0"]
-image:https://img.shields.io/badge/JVM-11--17-brightgreen.svg?style=for-the-badge["JVM support", link="https://github.com/kiegroup/optaplanner/actions/workflows/pull_request.yml"]
+image:https://img.shields.io/github/license/apache/incubator-kie-drools?style=for-the-badge&logo=apache["License", link="https://www.apache.org/licenses/LICENSE-2.0"]
 image:https://img.shields.io/badge/Maven-3.x-blue?style=for-the-badge["Maven",link="https://maven.apache.org/install.html"]
-image:https://img.shields.io/github/languages/code-size/kiegroup/optaplanner?style=for-the-badge["Code size", link="https://github.com/kiegroup/optaplanner/actions/workflows/pull_request.yml"]
-
-{sonarBadge}&style=for-the-badge&metric=reliability_rating["Reliability Rating", {sonarLink}]
-{sonarBadge}&metric=security_rating["Security Rating", {sonarLink}]
-{sonarBadge}&metric=sqale_rating["Maintainability Rating", {sonarLink}]
-{sonarBadge}&metric=coverage["Coverage", {sonarLink}]
 
 A fast, easy-to-use, open source AI constraint solver for software developers
 
@@ -73,28 +62,11 @@ and configure a _Run/Debug configuration_ like this:
 
 == Contributing to OptaPlanner
 
-This is an open source project, and you are more than welcome to contribute :heart:!
-
-
-* If you're just starting out with OptaPlanner and want to contribute,
-take a look at our https://issues.redhat.com/issues/?jql=project%20%3D%20PLANNER%20AND%20status%20in%20(Open%2C%20Reopened)%20AND%20labels%20%3D%20starter%20ORDER%20BY%20priority%20DESC[starter issues].
-They're specifically chosen to be easier for first time contributors.
-
-* If you want to contribute or start an opinionated discussion, join our https://groups.google.com/g/optaplanner-dev[discussion] or send an e-mail directly to optaplanner-dev@googlegroups.com.
-
-* If you want to submit an issue, check out the https://issues.redhat.com/projects/PLANNER/issues[OptaPlanner Jira project].
-
-=== Time to make a change?
-
-Every change must be submitted through a GitHub pull request (PR). OptaPlanner uses continuous integration (CI). The OptaPlanner CI  runs checks against your branch after you submit the PR to ensure that your PR doesn't introduce errors. If the CI identifies a potential problem, our friendly PR maintainers will help you resolve it.
-
-=== Contributing
-
-. Fork it (https://github.com/kiegroup/optaplanner).
-. Create your feature branch: (`git checkout -b feature`).
-. Commit your changes with a comment: (`git commit -am 'Add some feature'`).
-. Push to the branch to GitHub: (`git push origin feature`).
-. Create a new pull request.
+[NOTE]
+====
+*This repository is archived — contributions are no longer accepted here.*
+Please contribute to https://github.com/apache/incubator-kie-drools[apache/incubator-kie-drools] instead.
+====
 
 === Code standards
 
@@ -115,18 +87,3 @@ Use one of the following ways to build your OptaPlanner project:
 - :receipt: *build-doc*: `mvn clean install` at `optaplanner/optaplanner-docs` creates asciidoctor documentation `target/optaplanner-docs-*/html_single/index.html` (~2 min)
 
 - :mechanical_arm: *build-all*: `mvn clean install -Dfull` runs all checks + creates documentation and distribution files (~20 min)
-
-== OptaPlanner CI status
-
-You can check the CI status of the OptaPlanner repositories from the https://kiegroup.github.io/optaplanner/[Chain Status webpage].
-
-=== Jenkins CI Jobs (need VPN access) ===
-
-All Jenkins jobs can be found under the OptaPlanner folder: {jenkinsUrl}
-
-Interesting Jenkins CI jobs (need VPN access):
-
-- {toolsFolderJenkinsUrl}/job/update-quarkus-all/[Update Quarkus version]
-- {toolsFolderJenkinsUrl}/job/update-drools-optaplanner/[Update Drools version]
-- {releasefolderjenkinsurl}/job/optaplanner-release[Release pipeline] (only available on release branches)
-- {releasefolderjenkinsurl}/job/optaplanner-post-release[Post-Release pipeline] (only available on release branches)

--- a/README.adoc
+++ b/README.adoc
@@ -17,15 +17,17 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-image::optaplanner-docs/src/modules/ROOT/images/shared/optaPlannerLogo.png[link="https://www.optaplanner.org/",OptaPlanner,150,150,align="center"]
+> **ℹ️ NOTE**
+> 
+> *This repository's source code has moved!*
+>
+> The OptaPlanner codebase has been merged into the https://github.com/apache/incubator-kie-drools[apache/incubator-kie-drools] repository. Please use it for the latest source code, to file issues, and to submit contributions.
+>
+> This repository is archived.
 
-[WARNING]
-====
-*This repository is archived and no longer actively maintained.*
+---
 
-The OptaPlanner codebase has been merged into the https://github.com/apache/incubator-kie-drools[apache/incubator-kie-drools] repository.
-Please use that repository for the latest source code, to file issues, and to submit contributions.
-====
+image::https://raw.githubusercontent.com/apache/incubator-kie-docs/10.2.x/optaplanner-docs/src/modules/ROOT/images/shared/optaPlannerLogo.svg[link="https://www.optaplanner.org/",OptaPlanner,150,150,align="center"]
 
 image:https://img.shields.io/maven-central/v/org.optaplanner/optaplanner-bom?logo=apache-maven&style=for-the-badge["Maven artifact", link="https://ossindex.sonatype.org/component/pkg:maven/org.optaplanner/optaplanner-bom"]
 image:https://img.shields.io/badge/stackoverflow-ask_question-orange.svg?logo=stackoverflow&style=for-the-badge["Stackoverflow", link="https://stackoverflow.com/questions/tagged/optaplanner"]


### PR DESCRIPTION
Update readme to reflect archived status

<!--
Thank you for submitting this pull request.

Please provide all relevant information as outlined below. Feel free to delete
a section if that type of information is not available.
-->

### JIRA

<!-- Add a JIRA ticket link if it exists. -->
<!-- Example: https://issues.redhat.com/browse/PLANNER-1234 -->

### Referenced pull requests

<!-- Add URLs of all referenced pull requests if they exist. This is only required when making
changes that span multiple apache repositories and depend on each other. -->
<!-- Example:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234
- https://github.com/apache/incubator-kie-drools/pull/3000
- https://github.com/apache/incubator-kie-optaplanner/pull/899
- etc.
-->

### Checklist
- [ ] Documentation updated if applicable.
- [ ] Release notes updated if applicable.
- [ ] Upgrade recipe provided if applicable.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] tests</b>
  
- for a <b>full downstream build</b> 
  - for <b>jenkins</b> job: 
    please add comment: <b>Jenkins run fdb</b>
  - for <b>github actions</b> job: 
    add the label `run_fdb`

- for a <b>compile downstream build</b>  
  please add comment: <b>Jenkins run cdb</b>

- for a <b>full production downstream build</b>  
  please add comment: <b>Jenkins execute product fdb</b>

- for an <b>upstream build</b>  
  please add comment: <b>Jenkins run upstream</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-branch</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] quarkus-lts</b>

- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [optaplanner|optaplanner-quickstarts] native-lts</b>

</details>

### CI Status

 You can check OptaPlanner repositories CI status from [Chain Status webpage](https://apache.github.io/incubator-kie-optaplanner/).

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
